### PR TITLE
Integrate K-FAC from @n-gao

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/pytorch-kfac"]
+	path = extern/pytorch-kfac
+	url = https://github.com/n-gao/pytorch-kfac.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ black = ">=20-beta.0"
 pep8-naming = ">=0.7"
 isort = "^4.3"
 pydocstyle = "^5.0.1"
+torch-kfac = {path = "extern/pytorch-kfac"}
 
 [tool.poetry.scripts]
 deepqmc = "deepqmc.cli:cli"
@@ -76,3 +77,4 @@ pattern = '^(?P<base>\d+\.\d+\.\d+)$'
 [tool.black]
 target-version = ["py37"]
 skip-string-normalization = true
+exclude = "extern/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,7 @@ max-complexity = 12
 max-line-length = 80
 ignore = E501,W503,E741,E203,N802,N803,N806,E743,N812
 select = C,E,F,N,W,B,B9,Q0
-per-file-ignores =
-   ../notebooks/*.py:E703
+exclude = extern/
 
 [isort]
 multi_line_output = 3
@@ -14,6 +13,8 @@ sections = FUTURE,STDLIB,TYPING,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_typing = typing, typing_extensions
 no_lines_before = TYPING
 combine_as_imports = true
+skip_gitignore = true
+skip = extern/
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
First functional version, need to run tests and benchmarks before merging can be considered. Still a high probability there are bugs somewhere. Currently performance worse than with Adam and cycling scheduling.

Tested with:
```python
mol = Molecule.from_name('LiH')
net = PauliNet.from_hf(
    mol,
    cas=(4, 2),
).cuda()
# baseline is just `train(net, workdir='runs/test')`
train(
    net,
    workdir='runs/test',
    optimizer='SGD',
    epoch_size=1,
    learning_rate=1e-4,
    lr_scheduler=None,
    kfac=KFAC(
        net,
        learning_rate=1e-4,
        damping=1e-4,
        norm_constraint=1e-4,
        update_cov_manually=True,
    ),
    fit_kwargs={
        'subbatch_size': 100000,
    },
    sampler_kwargs={
        'n_discard': 30,
        'sample_size': 10_000,
    }
)
```

This gives me (gray: baseline, green: K-FAC):

<img width="348" alt="image" src="https://user-images.githubusercontent.com/940353/108896281-fd897680-7614-11eb-9175-e939f5801c03.png"> <img width="341" alt="image" src="https://user-images.githubusercontent.com/940353/108896332-0f6b1980-7615-11eb-8108-4de4c0bf7ab1.png">


Things to consider:
- [ ] Tune learning rate/damping/norm constraint
- [ ] Decay for the above
- [ ] Check KL variance updates
- [ ] Check against @deepqmc/torch-kfac
- [ ] Embeddings and cusp shifts are optimized with SGD+momentum only