### PR TITLE
Fix subbatch loss scaling

### DIFF
--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -155,11 +155,9 @@ def fit_wf(  # noqa: C901
                 Es_loc = Es_loc.where(mask, Es_loc.new_tensor(0))
             Es_loc_loss = log_clipped_outliers(Es_loc, q) if clip_outliers else Es_loc
             loss = loss_func(Es_loc_loss, log_psis, normalize_mean(log_ws.exp()))
-
             # The convention is that `loss_func` returns an *average* loss over
             # all the inputs. We scale it so that it works with subbatching.
             loss *= len(rs) / batch_size
-
             loss.backward()
             wf.sample(True)
             subbatches.append(

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,4 +1,5 @@
 import copy
+
 import torch
 
 from deepqmc import Molecule, evaluate, train


### PR DESCRIPTION
Currently, the training loss is computed as a _sum_ over sub-batch losses, which itself are _averages_ over contributions from individual samples. This makes the loss scale not invariant to the number of sub-batches, which is not the expected behaviour; moreover, the final sub-batch may end up being smaller, while contributing the same weight into the final loss.

In this PR, I fix the loss scaling so that the loss is _approximately_ invariant to sub-batch size. I also add a test which fails before the fix, and passes after (I've checked the former under 5 random seeds, and the latter under 20 seeds, so the test seems stable despite using `torch.isclose`).