### PR TITLE
refactor handling of the `unit` Molecule kwarg

### DIFF
--- a/src/deepqmc/data/systems.toml
+++ b/src/deepqmc/data/systems.toml
@@ -3,84 +3,98 @@ coords = [[1.0, 0.0, 0.0]]
 charges = [1]
 charge = 0
 spin = 1
+unit = 'angstrom'
 
 ["H2+"]
 coords = [[-0.52918, 0.0, 0.0], [0.52918, 0.0, 0.0]]
 charges = [1, 1]
 charge = 1
 spin = 1
+unit = 'angstrom'
 
 [H2]
 coords = [[0.0, 0.0, 0.0], [0.742, 0.0, 0.0]]
 charges = [1, 1]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [He]
 coords = [[0.0, 0.0, 0.0]]
 charges = [2]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [Be]
 coords = [[0.0, 0.0, 0.0]]
 charges = [4]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [B]
 coords = [[0.0, 0.0, 0.0]]
 charges = [5]
 charge = 0
 spin = 1
+unit = 'angstrom'
 
 [C]
 coords = [[0.0, 0.0, 0.0]]
 charges = [6]
 charge = 0
 spin = 2
+unit = 'angstrom'
 
 [LiH]
 coords = [[0.0, 0.0, 0.0], [1.595, 0.0, 0.0]]
 charges = [3, 1]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [CO2]
 coords = [[-1.161, 0.0, 0.0], [0.0, 0.0, 0.0], [1.161, 0.0, 0.0]]
 charges = [8, 6, 8]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [Li2]
 coords = [[-1.3364, 0.0, 0.0], [1.3364, 0.0, 0.0]]
 charges = [3, 3]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [Be2]
 coords = [[-1.230, 0.0, 0.0], [1.230, 0.0, 0.0]]
 charges = [4, 4]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [B2]
 coords = [[-0.7951, 0.0, 0.0], [0.7951, 0.0, 0.0]]
 charges = [5, 5]
 charge = 0
 spin = 2
+unit = 'angstrom'
 
 [C2]
 coords = [[-0.621265, 0.0, 0.0], [0.621265, 0.0, 0.0]]
 charges = [6, 6]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [N2]
 coords = [[-2.13534, 0.0, 0.0], [2.13534, 0.0, 0.0]]
 charges = [7, 7]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [H2O]
 coords = [
@@ -91,6 +105,7 @@ coords = [
 charges = [8, 1, 1]
 charge = 0
 spin = 0
+unit = 'angstrom'
 
 [bicyclobutane]
 coords = [

--- a/src/deepqmc/molecule.py
+++ b/src/deepqmc/molecule.py
@@ -20,6 +20,7 @@ _SYSTEM_FACTORIES = {
         'charges': np.ones(n),
         'charge': 0,
         'spin': n % 2,
+        'unit': 'angstrom',
     },
     'H4_rect': lambda dist: {
         'coords': np.array(
@@ -33,6 +34,7 @@ _SYSTEM_FACTORIES = {
         'charges': np.ones(4),
         'charge': 0,
         'spin': 0,
+        'unit': 'angstrom',
     },
 }
 
@@ -101,5 +103,5 @@ class Molecule(nn.Module):
             system.update(kwargs)
         elif name in _SYSTEM_FACTORIES:
             system = _SYSTEM_FACTORIES[name](**kwargs)
-        coords = np.array(system.pop('coords'), dtype=np.float32) * angstrom
+        coords = np.array(system.pop('coords'), dtype=np.float32)
         return cls(coords, **system)


### PR DESCRIPTION
This pull request modifies the handling of the `unit` kwarg of `Molecule`. The unit conversion factor is only applied in the constructor of `Molecule`. The default unit of bohr is now consistent between `systems.toml` and other ways of defining `Molecule`s.