### PR TITLE
remove obsolete code

### DIFF
--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -144,7 +144,7 @@ def fit_wf(  # noqa: C901
         ):
             Es_loc, log_psis, sign_psis = local_energy(
                 rs,
-                wf.sample(False),
+                wf,
                 create_graph=require_energy_gradient,
                 keep_graph=require_psi_gradient,
             )
@@ -160,7 +160,6 @@ def fit_wf(  # noqa: C901
             # all the inputs. We scale it so that it works with subbatching.
             loss *= len(rs) / batch_size
             loss.backward()
-            wf.sample(True)
             subbatches.append(
                 (
                     loss.detach().view(1),

--- a/src/deepqmc/wf/base.py
+++ b/src/deepqmc/wf/base.py
@@ -13,7 +13,6 @@ class WaveFunction(nn.Module):
 
     def __init__(self, mol):
         super().__init__()
-        self.sampling = True
         self.mol = mol
         n_elec = int(mol.charges.sum() - mol.charge)
         self.n_up = (n_elec + mol.spin) // 2
@@ -31,7 +30,3 @@ class WaveFunction(nn.Module):
 
     def forward(self, rs):
         return NotImplemented
-
-    def sample(self, mode=True):
-        self.sampling = mode
-        return self

--- a/tests/test_wf.py
+++ b/tests/test_wf.py
@@ -53,7 +53,12 @@ class OmniNet(nn.Module):
 
 
 @pytest.fixture(
-    params=[('paulinet', {'omni_factory': OmniNet, 'freeze_mos': False})],
+    params=[
+        (
+            'paulinet',
+            {'omni_factory': OmniNet, 'freeze_mos': False, 'use_sloglindet': False},
+        )
+    ],
     ids=['PauliNet(small)'],
 )
 def wf(request, mol):


### PR DESCRIPTION
Having decided to preferably switch to `use_sloglindet = 'always'`, and since we use the log output of the wave function in the rest of the code, we can now remove the unused leftovers.