### PR TITLE
Implement epochless training

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 ### Python code
 
 - [Black](https://github.com/psf/black) style
+- No extra blank lines
 - Has to pass [flake8](https://gitlab.com/pycqa/flake8)
 - Imports sorted with [isort](https://github.com/timothycrosley/isort)
 - [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) docstrings

--- a/src/deepqmc/evaluate.py
+++ b/src/deepqmc/evaluate.py
@@ -66,7 +66,7 @@ def evaluate(
             LangevinSampler.from_wf,
             sample_size=sample_size,
             n_discard=0,
-            **{'n_decorrelate': 4, **(sampler_kwargs or {})},
+            **{'n_decorrelate': 4, 'n_first_certain': 0, **(sampler_kwargs or {})},
         )
     sampler = sampler_factory(wf, writer=writer)
     steps = tqdm(count(), desc='equilibrating', disable=None)

--- a/src/deepqmc/torchext/__init__.py
+++ b/src/deepqmc/torchext/__init__.py
@@ -4,7 +4,6 @@ from .sloglindet import sloglindet
 from .utils import (
     SSP,
     argmax_random_choice,
-    assign_where,
     batch_eval,
     batch_eval_tuple,
     bdiag,
@@ -28,7 +27,6 @@ from .utils import (
 
 __all__ = [
     'SSP',
-    'assign_where',
     'argmax_random_choice',
     'batch_eval',
     'batch_eval_tuple',

--- a/src/deepqmc/torchext/utils.py
+++ b/src/deepqmc/torchext/utils.py
@@ -36,12 +36,6 @@ def weighted_mean_var(xs, log_ws):
     return mean, (ws * (xs - mean) ** 2).mean()
 
 
-def assign_where(xs, ys, where):
-    assert len(xs) == len(ys)
-    for x, y in zip(xs, ys):
-        x[where] = y[where]
-
-
 def merge_tensors(mask, source_true, source_false):
     x = torch.empty_like(mask, dtype=source_false.dtype)
     x[mask] = source_true

--- a/src/deepqmc/utils.py
+++ b/src/deepqmc/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 __all__ = ()
 
@@ -61,3 +62,11 @@ class _EnergyOffset:
 
 
 energy_offset = _EnergyOffset()
+
+
+def apply_resampling(weights: torch.Tensor, strategy: str):
+    num_samples = len(weights)
+    if strategy == 'multinomial':
+        return torch.multinomial(weights, num_samples, replacement=True)
+    else:
+        raise ValueError(f'Unknown resampling strategy {strategy}.')

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,18 +1,27 @@
 import copy
 
+import pytest
 import torch
 
 from deepqmc import Molecule, evaluate, train
 from deepqmc.wf import PauliNet
 
 
-def test_simple_example(tmp_path):
+@pytest.mark.parametrize('with_resampling', [False, True])
+def test_simple_example(tmp_path, with_resampling):
     mol = Molecule.from_name('LiH')
     net = PauliNet.from_hf(mol, cas=(4, 2), conf_limit=2)
+    if with_resampling:
+        resampling_kwargs = {
+            'keep_walker_weights': True,
+            'resampling_frequency': 1,
+        }
+    else:
+        resampling_kwargs = {}
     chkpts = []
     train(
         net,
-        n_steps=3,
+        n_steps=4,
         batch_size=5,
         save_every=2,
         epoch_size=3,
@@ -25,6 +34,7 @@ def test_simple_example(tmp_path):
             'n_discard': 0,
             'n_decorrelate': 0,
             'n_first_certain': 0,
+            **resampling_kwargs,
         },
     )
     train(


### PR DESCRIPTION
This PR adds an option to maintain importance weights on the walkers which are not reset every epoch, and instead only during periodic resampling. This makes it possible to remove the assumption that the first `n_discard` steps in each epoch are enough to equilibrate the walkers. Without that assumption, one may set `epoch_size = 1`, and effectively get an epochless setup, although many other variations are possible.

Empirically, epochless training was tested on a variety of systems, showing improved stability and convergence.