### PR TITLE
adapt default population charges for charged molecules

### DIFF
--- a/src/deepqmc/wf/base.py
+++ b/src/deepqmc/wf/base.py
@@ -26,7 +26,7 @@ class WaveFunction(nn.Module):
         return slice(None, self.n_up), slice(self.n_up, None)
 
     def pop_charges(self):
-        return torch.zeros_like(self.mol.charges)
+        return torch.zeros_like(self.mol.charges) + self.mol.charge / len(self.mol)
 
     def forward(self, rs):
         return NotImplemented


### PR DESCRIPTION
When initializing a wave function for charged molecules without providing a pyscf mf object the population charges should reflect the total charge. This fixes a `rand_from_mol` call on a charged molecule while providing the default population charges of the respective wave function ansatz.