### PR TITLE
delay importing jax

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -6,7 +6,6 @@ import warnings
 from pathlib import Path
 
 import hydra
-import jax
 import yaml
 from hydra.utils import call, get_original_cwd, to_absolute_path
 from omegaconf import OmegaConf
@@ -104,6 +103,8 @@ def maybe_log_code_version():
 
 
 def main(cfg):
+    import jax
+
     log.info('Entering application')
     jax.config.update('jax_platform_name', cfg.device)
     log.info(f'Running on {cfg.device.upper()}')


### PR DESCRIPTION
Upon import, JAX performs some checks regarding CPU instruction sets. If DeepQMC is run with the submitit launcher, this can trigger spurious error messages, if the submitting node of a SLURM cluster doesn't have the proper CPU instruction set, but the actual work nodes would have it. By import JAX only in the main function, we delay these checks until the job has actually moved to the work node.