### PR TITLE
ignore flake8-bugbear warning B905

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-complexity = 12
 max-line-length = 80
-ignore = E501,W503,E741,E203,N802,N803,N806,E743,N812,N818,E731,B020
+ignore = E501,W503,E741,E203,N802,N803,N806,E743,N812,N818,E731,B020,B905
 select = C,E,F,N,W,B,B9,Q0
 per-file-ignores =
    ../notebooks/*.py:E703


### PR DESCRIPTION
Version 22.12.6 of flake8-bugbear introduced the warning B905 for `zip` not having an explicit `strict` parameter. This parameter only exists in python 3.10 and higher. Since we support also python 3.9, we cannot add this parameter to our `zip` calls. The warning should therefore be ignored.