### PR TITLE
Initialize smpl_state after pretraining

### DIFF
--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -10,7 +10,7 @@ import optax
 
 from .kfacext import make_graph_patterns
 from .utils import check_overflow, exp_normalize_mean, masked_mean, tree_norm
-from .wf.base import init_wf
+from .wf.base import init_wf_params
 
 __all__ = ()
 log = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def median_log_squeeze(x, width, quantile):
 
 
 def init_fit(rng, hamil, ansatz, sampler, sample_size, state_callback):
-    params, wf_state = init_wf(rng, hamil, ansatz, sample_size, state_callback)
+    params = init_wf_params(rng, hamil, ansatz)
     smpl_state = sampler.init(
         rng, partial(ansatz.apply, params), sample_size, state_callback
     )

--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -37,7 +37,7 @@ def median_log_squeeze(x, width, quantile):
 def init_fit(rng, hamil, ansatz, sampler, sample_size, state_callback):
     params, wf_state = init_wf(rng, hamil, ansatz, sample_size, state_callback)
     smpl_state = sampler.init(
-        rng, partial(ansatz.apply, params), wf_state, sample_size, state_callback
+        rng, partial(ansatz.apply, params), sample_size, state_callback
     )
     return params, smpl_state
 

--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -10,6 +10,7 @@ import optax
 
 from .kfacext import make_graph_patterns
 from .utils import check_overflow, exp_normalize_mean, masked_mean, tree_norm
+from .wf.base import init_wf
 
 __all__ = ()
 log = logging.getLogger(__name__)
@@ -34,8 +35,7 @@ def median_log_squeeze(x, width, quantile):
 
 
 def init_fit(rng, hamil, ansatz, sampler, sample_size, state_callback):
-    r = hamil.init_sample(rng, sample_size)
-    params, wf_state = jax.vmap(ansatz.init, (None, 0), (None, 0))(rng, r)
+    params, wf_state = init_wf(rng, hamil, ansatz, sample_size, state_callback)
     smpl_state = sampler.init(
         rng, partial(ansatz.apply, params), wf_state, sample_size, state_callback
     )

--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -88,7 +88,7 @@ def pretrain(  # noqa: C901
         rng, init_r, False
     )
     baseline = partial(ansatz_baseline.apply, params_baseline)
-    smpl_state = sampler.init(rng, baseline, {}, sample_size, state_callback)
+    smpl_state = sampler.init(rng, baseline, sample_size, state_callback)
     opt_state = opt.init(params)
 
     @jax.jit

--- a/src/deepqmc/sampling.py
+++ b/src/deepqmc/sampling.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 class Sampler:
     r"""Base class for all QMC samplers."""
 
-    def init(self, rng, wf, wf_state, n, state_callback=None):
+    def init(self, rng, wf, n, state_callback=None, wf_state=None):
         raise NotImplementedError
 
     def sample(self, rng, state, wf):
@@ -62,12 +62,12 @@ class MetropolisSampler(Sampler):
         state = {**state, 'psi': psi, 'wf': wf_state}
         return state
 
-    def init(self, rng, wf, wf_state, n, state_callback=None):
+    def init(self, rng, wf, n, state_callback=None, wf_state=None):
         state = {
             'r': self.hamil.init_sample(rng, n),
             'age': jnp.zeros(n, jnp.int32),
             'tau': jnp.array(self.initial_tau),
-            'wf': wf_state,
+            'wf': wf_state or {},
         }
 
         @partial(check_overflow, state_callback)
@@ -212,8 +212,8 @@ class ResampledSampler(Sampler):
         self.period = period
         self.treshold = treshold
 
-    def init(self, *args):
-        state = super().init(*args)
+    def init(self, *args, **kwargs):
+        state = super().init(*args, **kwargs)
         state = {
             **state,
             'step': jnp.array(0),

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -23,7 +23,7 @@ from .physics import pairwise_self_distance
 from .pretrain import pretrain
 from .sampling import equilibrate
 from .utils import InverseSchedule
-from .wf.base import init_wf, state_callback
+from .wf.base import init_wf_params, state_callback
 
 __all__ = ['train']
 
@@ -150,7 +150,7 @@ def train(  # noqa: C901
                 }[mode]
             )
         else:
-            params, _ = init_wf(rng, hamil, ansatz, sample_size, state_callback)
+            params = init_wf_params(rng, hamil, ansatz)
             num_params = jax.tree_util.tree_reduce(
                 operator.add, jax.tree_map(lambda x: x.size, params)
             )

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -17,13 +17,13 @@ from tqdm.auto import tqdm, trange
 from uncertainties import ufloat
 
 from .ewm import init_ewm
-from .fit import fit_wf, init_fit
+from .fit import fit_wf
 from .log import H5LogTable, update_tensorboard_writer
 from .physics import pairwise_self_distance
 from .pretrain import pretrain
 from .sampling import equilibrate
 from .utils import InverseSchedule
-from .wf.base import state_callback
+from .wf.base import init_wf, state_callback
 
 __all__ = ['train']
 
@@ -150,9 +150,7 @@ def train(  # noqa: C901
                 }[mode]
             )
         else:
-            params, _ = init_fit(
-                rng, hamil, ansatz, sampler, sample_size, state_callback
-            )
+            params, _ = init_wf(rng, hamil, ansatz, sample_size, state_callback)
             num_params = jax.tree_util.tree_reduce(
                 operator.add, jax.tree_map(lambda x: x.size, params)
             )

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -186,7 +186,7 @@ def train(  # noqa: C901
                     if workdir:
                         update_tensorboard_writer(writer, step, pretrain_stats)
             smpl_state = sampler.init(
-                rng, partial(ansatz.apply, params), {}, sample_size, state_callback
+                rng, partial(ansatz.apply, params), sample_size, state_callback
             )
             log.info('Equilibrating sampler...')
             pbar = tqdm(

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -150,7 +150,7 @@ def train(  # noqa: C901
                 }[mode]
             )
         else:
-            params, smpl_state = init_fit(
+            params, _ = init_fit(
                 rng, hamil, ansatz, sampler, sample_size, state_callback
             )
             num_params = jax.tree_util.tree_reduce(
@@ -187,6 +187,9 @@ def train(  # noqa: C901
                     }
                     if workdir:
                         update_tensorboard_writer(writer, step, pretrain_stats)
+            smpl_state = sampler.init(
+                rng, partial(ansatz.apply, params), {}, sample_size, state_callback
+            )
             log.info('Equilibrating sampler...')
             pbar = tqdm(
                 count() if max_eq_steps is None else range(max_eq_steps),

--- a/src/deepqmc/wf/base.py
+++ b/src/deepqmc/wf/base.py
@@ -6,6 +6,13 @@ from jax.tree_util import tree_map, tree_reduce
 __all__ = ['state_callback']
 
 
+def init_wf(rng, hamil, ansatz, sample_size, state_callback):
+    r = hamil.init_sample(rng, sample_size)
+    params, wf_state = jax.vmap(ansatz.init, (None, 0), (None, 0))(rng, r)
+    wf_state, _ = state_callback(wf_state)
+    return params, wf_state
+
+
 class WaveFunction(hk.Module):
     r"""
     Base class for all trial wave functions.

--- a/src/deepqmc/wf/base.py
+++ b/src/deepqmc/wf/base.py
@@ -6,11 +6,11 @@ from jax.tree_util import tree_map, tree_reduce
 __all__ = ['state_callback']
 
 
-def init_wf(rng, hamil, ansatz, sample_size, state_callback):
-    r = hamil.init_sample(rng, sample_size)
-    params, wf_state = jax.vmap(ansatz.init, (None, 0), (None, 0))(rng, r)
-    wf_state, _ = state_callback(wf_state)
-    return params, wf_state
+def init_wf_params(rng, hamil, ansatz):
+    rng_hamil, rng_params = jax.random.split(rng)
+    r = hamil.init_sample(rng_hamil, 1)[0]
+    params, _ = ansatz.init(rng_params, r)
+    return params
 
 
 class WaveFunction(hk.Module):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -48,7 +48,7 @@ class TestSampling:
     def test_sampler_init(self, helpers, samplers, ndarrays_regression):
         sampler = chain(*samplers[:-1], samplers[-1](self.hamil))
         smpl_state = sampler.init(
-            helpers.rng(), self.wf, self.wf_state, self.SAMPLE_SIZE, state_callback
+            helpers.rng(), self.wf, self.SAMPLE_SIZE, state_callback, self.wf_state
         )
         ndarrays_regression.check(
             helpers.flatten_pytree(smpl_state),
@@ -58,7 +58,7 @@ class TestSampling:
     def test_sampler_sample(self, helpers, samplers, ndarrays_regression):
         sampler = chain(*samplers[:-1], samplers[-1](self.hamil))
         smpl_state = sampler.init(
-            helpers.rng(), self.wf, self.wf_state, self.SAMPLE_SIZE, state_callback
+            helpers.rng(), self.wf, self.SAMPLE_SIZE, state_callback, self.wf_state
         )
         sample = check_overflow(state_callback, sampler.sample)
         for step in range(4):


### PR DESCRIPTION
Currently, `smpl_state` is initialized before pretraining, but it should be initialized after. This is because `smpl_state` contains `psi` values. It can occur that the Ansatz at initialization has `psi` values on a completely different order of magnitude to the Ansatz after pretraining. This can then cause the MCMC to never move away from its initial location.