### PR TITLE
improve logging

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -39,7 +39,7 @@ The evaluation of the energy of a trained wavefunction ansatz is obtained via::
 
     $ deepqmc task=evaluate task.restdir=workdir
 
-This again generates a Tensorboard event file ``evalutaion\events.out.tfevents.*`` and an HDF5 file ``evalutaion\result.h5`` file holding the sampled local energies.
+This again generates a Tensorboard event file ``evaluation\events.out.tfevents.*`` and an HDF5 file ``evaluation\result.h5`` file holding the sampled local energies.
 
 .. _hyperparameters:
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -27,9 +27,9 @@ A training can be run via::
 
 This creates several files in the working directory, including:
 
-- ``train/events.out.tfevents.*`` - Tensorboard event file
-- ``train/result.h5`` - HDF5 file with the training trajectory
-- ``train/state-*.pt`` - Checkpoint files with the saved state of the ansatz at particular steps
+- ``training/events.out.tfevents.*`` - Tensorboard event file
+- ``training/result.h5`` - HDF5 file with the training trajectory
+- ``training/state-*.pt`` - Checkpoint files with the saved state of the ansatz at particular steps
 
 The training can be continued or recoverd from a training checkpoint::
 
@@ -39,7 +39,7 @@ The evaluation of the energy of a trained wavefunction ansatz is obtained via::
 
     $ deepqmc task=evaluate task.restdir=workdir
 
-This again generates a Tensorboard event file and a ``sample.h5`` file holding the sampled local energies.
+This again generates a Tensorboard event file ``evalutaion\events.out.tfevents.*`` and an HDF5 file ``evalutaion\result.h5`` file holding the sampled local energies.
 
 .. _hyperparameters:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -93,10 +93,10 @@ The terminal output shows only how far has the training progressed and the curre
 
 This launches a Tensorboard server which can be accessed via a web browser at the printed URL.
 
-Furthermore the training run is logged to the ``workdir``. The ``train`` directory contains training checkpoints as well as an hdf5 file ``result.h5`` that holds the local energies throughout the training, an exponential moving average of the training energy and the values of the wave function at every iteration::
+Furthermore the training run is logged to the ``workdir``. The ``training`` directory contains training checkpoints as well as an hdf5 file ``result.h5`` that holds the local energies throughout the training, an exponential moving average of the training energy and the values of the wave function at every iteration::
 
     >>> import h5py
-    >>> with h5py.File('workdir/train/result.h5') as f: print(f.keys())
+    >>> with h5py.File('workdir/training/result.h5') as f: print(f.keys())
     <KeysViewHDF5 ['E_ewm', 'E_loc', 'log_psi', 'sign_psi']>
 
 Get the energy
@@ -105,8 +105,8 @@ Get the energy
 The rough estimate of the expectation value of the energy of a trained wave function can be obtained already from the training run. A rigorous estimation with a statistical sampling error can be obtained when sampling the energy expectation value of the trained wavefunction without further optimization, for which the final training checkpoint is passed to the :func:`~deepqmc.train` function, but the optimizer is specified to be ``None``:
 
     >>> import jax.numpy as jnp
-    >>> train_state = jnp.load('workdir/train/chkpt-10000.pt',allow_pickle=True)
+    >>> train_state = jnp.load('workdir/training/chkpt-10000.pt',allow_pickle=True)
     >>> train(H, net, None, sampler, train_state=train_state, steps=500, sample_size=2000, seed=42)
     evaluating: 100%|█████████| 500/500 [01:20<00:00,  6.20it/s, E=-8.07000(19)]
 
-The evaluation generates the same type of logs as the training, but writes to ``workdir/evaluate`` instead. The final energy can be read from the progress bar, the Tensorboard event file or computed from the local enregies in the hdf5 file respectively.
+The evaluation generates the same type of logs as the training, but writes to ``workdir/evaluation`` instead. The final energy can be read from the progress bar, the Tensorboard event file or computed from the local enregies in the hdf5 file respectively.

--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -62,7 +62,7 @@ def task_from_workdir(workdir, chkpt):
     if chkpt == 'LAST':
         chkpts = list(workdir.glob(CheckpointStore.PATTERN.format('*')))
         if not chkpts:
-            chkpts = (workdir / 'train').glob(CheckpointStore.PATTERN.format('*'))
+            chkpts = (workdir / 'training').glob(CheckpointStore.PATTERN.format('*'))
         chkpt = sorted(chkpts)[-1]
     else:
         chkpt = workdir / chkpt

--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -19,6 +19,11 @@ warnings.filterwarnings(
     'provider=hydra.searchpath in main, path=conf is not available.',
     UserWarning,
 )
+warnings.filterwarnings(
+    'ignore',
+    'Some donated buffers were not usable:',
+    UserWarning,
+)
 
 
 def instantiate_ansatz(hamil, ansatz):
@@ -105,6 +110,9 @@ def maybe_log_code_version():
 def main(cfg):
     import jax
 
+    log.setLevel(cfg.logging.deepqmc)
+    logging.getLogger('jax').setLevel(cfg.logging.jax)
+    logging.getLogger('absl').setLevel(cfg.logging.kfac)
     log.info('Entering application')
     jax.config.update('jax_platform_name', cfg.device)
     log.info(f'Running on {cfg.device.upper()}')

--- a/src/deepqmc/conf/config.yaml
+++ b/src/deepqmc/conf/config.yaml
@@ -15,3 +15,7 @@ hydra:
 task:
   workdir: ???
 device: cuda
+logging:
+  deepqmc: 20
+  jax: 40
+  kfac: 40

--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -1,4 +1,3 @@
-import logging
 from collections import namedtuple
 from functools import partial
 
@@ -13,7 +12,6 @@ from .utils import check_overflow, exp_normalize_mean, masked_mean, tree_norm
 from .wf.base import init_wf_params
 
 __all__ = ()
-log = logging.getLogger(__name__)
 
 TrainState = namedtuple('TrainState', 'sampler params opt')
 

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -98,7 +98,7 @@ class H5LogTable:
         return Appender()
 
 
-def update_tensorboard_writer(writer, step, stats):
+def update_tensorboard_writer(writer, step, stats, prefix=None):
     r"""Update a tensorboard writer with a dictionary of scalar entries.
 
     Args:
@@ -107,4 +107,4 @@ def update_tensorboard_writer(writer, step, stats):
         stats (dict): a dictionary containing the scalar entries to add.
     """
     for k, v in stats.items():
-        writer.add_scalar(k, v, step)
+        writer.add_scalar(f'{prefix}/{k}' if prefix else k, v, step)

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -1,5 +1,51 @@
+import pickle
+from collections import namedtuple
+from copy import deepcopy
+from pathlib import Path
+
 import jax.numpy as jnp
 import numpy as np
+
+Checkpoint = namedtuple('Checkpoint', 'step loss path')
+
+
+class CheckpointStore:
+    PATTERN = 'chkpt-{}.pt'
+
+    def __init__(self, workdir, *, size=3, min_interval=100, threshold=0.95):
+        self.workdir = Path(workdir)
+        for p in self.workdir.glob(self.PATTERN.format('*')):
+            p.unlink()
+        self.size = size
+        self.min_interval = min_interval
+        self.threshold = threshold
+        self.chkpts = []
+        self.buffer = None
+
+    def update(self, step, state, loss=jnp.inf):
+        self.buffer = (step, loss, deepcopy(state))
+        if step > self.min_interval + (self.chkpts[-1].step if self.chkpts else 0) and (
+            loss <= self.threshold * (self.chkpts[-1].loss if self.chkpts else jnp.inf)
+        ):
+            self.dump(step, state, loss)
+
+    def dump(self, step, state, loss=jnp.inf):
+        path = self.workdir / self.PATTERN.format(step)
+        with path.open('wb') as f:
+            pickle.dump((step, state), f)
+        self.chkpts.append(Checkpoint(step, loss, path))
+        while len(self.chkpts) > self.size:
+            self.chkpts.pop(0).path.unlink()
+
+    def close(self):
+        if self.buffer is not None:
+            self.dump(*self.buffer)
+
+    @property
+    def last(self):
+        chkpt = self.chkpts[-1]
+        with chkpt.path.open('rb') as f:
+            return pickle.load(f)
 
 
 class H5LogTable:

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -10,6 +10,15 @@ Checkpoint = namedtuple('Checkpoint', 'step loss path')
 
 
 class CheckpointStore:
+    r"""Stores training checkpoints in the working directory.
+
+    Args:
+        workdir (str): path where checkpoints are stored.
+        size (int): maximum number of checkpoints stored at any time.
+        min_interval (str): minimum number of steps between two checkpoints.
+        threshold (float): treshold for decrease in criterion for new checkpoint.
+    """
+
     PATTERN = 'chkpt-{}.pt'
 
     def __init__(self, workdir, *, size=3, min_interval=100, threshold=0.95):

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -118,7 +118,7 @@ def train(  # noqa: C901
 
     ewm_state, update_ewm = init_ewm()
     rng = jax.random.PRNGKey(seed)
-    mode = 'evaluate' if opt is None else 'train'
+    mode = 'evaluation' if opt is None else 'training'
     if isinstance(opt, str):
         opt_kwargs = OPT_KWARGS.get(opt, {}) | (opt_kwargs or {})
         opt = (
@@ -141,8 +141,8 @@ def train(  # noqa: C901
         if train_state:
             log.info(
                 {
-                    'train': f'Restart training from step {init_step}',
-                    'evaluate': 'Start evaluate',
+                    'training': f'Restart training from step {init_step}',
+                    'evaluation': 'Start evaluation',
                 }[mode]
             )
         else:
@@ -152,8 +152,8 @@ def train(  # noqa: C901
                 operator.add, jax.tree_map(lambda x: x.size, params)
             )
             log.info(f'Number of model parameters: {num_params}')
-            if pretrain_steps and mode == 'train':
-                log.info('Pretraining wrt. HF wave function')
+            if pretrain_steps and mode == 'training':
+                log.info('Pretraining wrt. baseline wave function')
                 rng, rng_pretrain = jax.random.split(rng)
                 pretrain_kwargs = pretrain_kwargs or {}
                 opt_pretrain = pretrain_kwargs.pop('opt', 'adamw')
@@ -208,7 +208,7 @@ def train(  # noqa: C901
                 #     update_tensorboard_writer(writer, step, stats)
             pbar.close()
             train_state = smpl_state, params, None
-            if workdir and mode == 'train':
+            if workdir and mode == 'training':
                 chkpts.dump(init_step, train_state)
             log.info(f'Start {mode}')
         best_ene = None
@@ -260,7 +260,7 @@ def train(  # noqa: C901
                             best_ene = ene
                             log.info(f'Progress: {step + 1}/{steps}, energy = {ene:S}')
                     if workdir:
-                        if mode == 'train':
+                        if mode == 'training':
                             # the convention is that chkpt-i contains the step i-1 -> i
                             chkpts.update(step + 1, train_state, stats['E_loc/std'])
                         table.row['E_loc'] = E_loc

--- a/src/deepqmc/wf/baseline/pyscfext.py
+++ b/src/deepqmc/wf/baseline/pyscfext.py
@@ -27,15 +27,18 @@ def pyscf_from_mol(mol, basis, cas=None, **kwargs):
         spin=mol.spin,
         cart=True,
         parse_arg=False,
+        verbose=0,
         **kwargs,
     )
     log.info('Running HF...')
     mf = RHF(mol)
     mf.kernel()
+    log.info(f'HF energy: {mf.e_tot}')
     if cas:
         log.info('Running MCSCF...')
         mc = CASSCF(mf, *cas)
         mc.kernel()
+        log.info(f'MCSCF energy: {mc.e_tot}')
     return mol, (mf, mc if cas else None)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,8 +16,8 @@ class TestApp:
         )
         files = os.listdir(tmpdir)
         assert 'deepqmc.log' in files
-        assert 'train' in files
-        train_files = os.listdir(tmpdir / 'train')
+        assert 'training' in files
+        train_files = os.listdir(tmpdir / 'training')
         assert 'result.h5' in train_files
         assert any(f.startswith('events.out.tfevents.') for f in train_files)
-        assert 'Start train' in result.stdout.decode()
+        assert 'Start training' in result.stdout.decode()


### PR DESCRIPTION
This pull request 

- makes the deepqmc log more readable
- changes the default verbosity of jax and kfac and enables to customize it for debugging through the cli
- renames the train modes from _train_ and _evaluate_ to _training_ and _evaluation_ and adapts the docs accordingly
-  fixes issues with the display of progress bars
-  includes missing quantities to the tensorboard writer
-  implements minor refactors that are related to the above