### PR TITLE
fix pretraining

### DIFF
--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -88,7 +88,7 @@ def pretrain(  # noqa: C901
         rng, init_r, False
     )
     baseline = partial(ansatz_baseline.apply, params_baseline)
-    smpl_state = sampler.init(rng, baseline, {}, sample_size)
+    smpl_state = sampler.init(rng, baseline, sample_size)
     opt_state = opt.init(params)
 
     @jax.jit

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 
 class TestApp:
-    ARGS = ['deepqmc', 'device=cpu', 'task.steps=0', '+task.max_eq_steps=0']
+    ARGS = [
+        'deepqmc',
+        'hamil.mol.name=H2',
+        'device=cpu',
+        'task.steps=1',
+        '+task.max_eq_steps=1',
+        '+task.pretrain_steps=1',
+    ]
 
     def test_train(self, tmpdir):
         tmpdir = Path(tmpdir)
@@ -20,4 +27,7 @@ class TestApp:
         train_files = os.listdir(tmpdir / 'training')
         assert 'result.h5' in train_files
         assert any(f.startswith('events.out.tfevents.') for f in train_files)
+        assert 'Pretraining completed' in result.stdout.decode()
+        assert 'Equilibrating sampler...' in result.stdout.decode()
         assert 'Start training' in result.stdout.decode()
+        assert 'The training has been completed!' in result.stdout.decode()


### PR DESCRIPTION
This pull request fixes a minor bug in the sampler initialization of the pretraining related to #72 . In order to prevent this in future pull requests a minimal training run consisting of one pretraining step, one equilibration step and one training step on H2 is introduced to the tests.