### PR TITLE
update psi values in sampler

### DIFF
--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -192,6 +192,7 @@ def fit_wf(  # noqa: C901
             rng_kfac, smpl_state['wf'], params, opt_state, (r, weight)
         )
         if opt is not None:
+            # WF was changed in _step, update psi values stored in smpl_state
             smpl_state = update_sampler(smpl_state, params)
         stats = {
             **smpl_stats,


### PR DESCRIPTION
This pull request fixes #77. The psi values in the samplers are manually updated eacch time a gradient step is applied. If a variant of the resampled sampler is used the importance weights are logged in that process. 