### PR TITLE
Minor fixes

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -24,6 +24,11 @@ warnings.filterwarnings(
     'Some donated buffers were not usable:',
     UserWarning,
 )
+warnings.filterwarnings(
+    'ignore',
+    'Explicitly requested dtype',
+    UserWarning,
+)
 
 
 def instantiate_ansatz(hamil, ansatz):

--- a/src/deepqmc/conf/config_slurm.yaml
+++ b/src/deepqmc/conf/config_slurm.yaml
@@ -17,3 +17,7 @@ hydra:
 task:
   workdir: ???
 device: cuda
+logging:
+  deepqmc: 20
+  jax: 40
+  kfac: 40


### PR DESCRIPTION
Fix `config_slurm.yaml` by adding the logging configuration fields.

Suppress JAX warnings caused by `e3nn-jax==0.14.0`.