### PR TITLE
Loosen test tolerance

### DIFF
--- a/src/deepqmc/gnn/gnn.py
+++ b/src/deepqmc/gnn/gnn.py
@@ -143,13 +143,10 @@ class GraphNeuralNetwork(hk.Module):
             },
             'node_types': {
                 'nuclei': (
-                    (
-                        jnp.unique(charges, size=n_nuc, return_inverse=True)[-1]
-                        if atom_type_embeddings
-                        else jnp.arange(n_nuc)
-                    )
-                    + (1 if n_up == n_down else 2)
-                ),
+                    jnp.unique(charges, size=n_nuc, return_inverse=True)[-1]
+                    if atom_type_embeddings
+                    else jnp.arange(n_nuc)
+                ) + (1 if n_up == n_down else 2),
                 'electrons': jnp.array(n_up * [0] + n_down * [int(n_up != n_down)]),
             },
         }

--- a/src/deepqmc/gnn/schnet.py
+++ b/src/deepqmc/gnn/schnet.py
@@ -75,9 +75,11 @@ class SchNetLayer(MessagePassingLayer):
 
         self.w = {
             typ: MLP(
-                self.edge_feat_dim[typ]
-                if not deep_w or self.first_layer
-                else self.embedding_dim,
+                (
+                    self.edge_feat_dim[typ]
+                    if not deep_w or self.first_layer
+                    else self.embedding_dim
+                ),
                 self.embedding_dim,
                 name=f'w_{typ}',
                 **subnet_kwargs_by_lbl['w'],

--- a/src/deepqmc/kfacext.py
+++ b/src/deepqmc/kfacext.py
@@ -66,9 +66,11 @@ def make_dense_pattern(
     p_shapes = [[in_dim, out_dim], [out_dim]] if with_bias else [[in_dim, out_dim]]
     compute_func = vmap(_dense, in_axes=(0, None))
     return kfac_jax.tag_graph_matcher.GraphPattern(
-        name=f'repeated{n_extra_dims}_dense_with_bias'
-        if with_bias
-        else f'repeated{n_extra_dims}_dense_no_bias',
+        name=(
+            f'repeated{n_extra_dims}_dense_with_bias'
+            if with_bias
+            else f'repeated{n_extra_dims}_dense_no_bias'
+        ),
         tag_primitive=kfac_jax.LayerTag(f'repeated{n_extra_dims}_dense_tag', 1, 1),
         #  precedence=0 if with_bias else 1,
         compute_func=compute_func,

--- a/src/deepqmc/wf/paulinet/omni.py
+++ b/src/deepqmc/wf/paulinet/omni.py
@@ -191,10 +191,12 @@ class OmniNet(hk.Module):
             None
             if not self.backflow
             else (
-                self.backflow['up'](embeddings[..., : self.n_up, :]),
-                self.backflow['down'](embeddings[..., self.n_up :, :]),
+                (
+                    self.backflow['up'](embeddings[..., : self.n_up, :]),
+                    self.backflow['down'](embeddings[..., self.n_up :, :]),
+                )
+                if isinstance(self.backflow, dict)
+                else self.backflow(embeddings)
             )
-            if isinstance(self.backflow, dict)
-            else self.backflow(embeddings)
         )
         return jastrow, backflow

--- a/tests/test_gnn.py
+++ b/tests/test_gnn.py
@@ -80,9 +80,9 @@ class TestSchNet:
             {'layer_kwargs': {'shared_g': True}},
             {'layer_kwargs': {'shared_h': True}},
         ],
-        ids=lambda x: ','.join(f'{k}={v}' for k, v in x.items())
-        if isinstance(x, dict)
-        else x,
+        ids=lambda x: (
+            ','.join(f'{k}={v}' for k, v in x.items()) if isinstance(x, dict) else x
+        ),
     )
     def test_embedding(self, helpers, ndarrays_regression, kwargs):
         mol = helpers.mol()

--- a/tests/test_paulinet.py
+++ b/tests/test_paulinet.py
@@ -12,9 +12,9 @@ from deepqmc.physics import laplacian
         ({'backflow_channels': 2}, {}),
         ({'confs': [[0, 1, 0, 1], [0, 2, 0, 2]]}, {}),
     ],
-    ids=lambda x: ','.join(f'{k}={v}' for k, v in x.items())
-    if isinstance(x, dict)
-    else x,
+    ids=lambda x: (
+        ','.join(f'{k}={v}' for k, v in x.items()) if isinstance(x, dict) else x
+    ),
 )
 class TestPauliNet:
     def test_psi(self, helpers, kwargs, omni_kwargs, ndarrays_regression):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -52,7 +52,7 @@ class TestSampling:
         )
         ndarrays_regression.check(
             helpers.flatten_pytree(smpl_state),
-            default_tolerance={'rtol': 1e-4, 'atol': 1e-6},
+            default_tolerance={'rtol': 5e-4, 'atol': 1e-6},
         )
 
     def test_sampler_sample(self, helpers, samplers, ndarrays_regression):
@@ -65,5 +65,5 @@ class TestSampling:
             smpl_state, _, stats = sample(helpers.rng(step), smpl_state, self.wf)
         ndarrays_regression.check(
             helpers.flatten_pytree({'smpl_state': smpl_state, 'stats': stats}),
-            default_tolerance={'rtol': 1e-4, 'atol': 1e-6},
+            default_tolerance={'rtol': 5e-4, 'atol': 1e-6},
         )


### PR DESCRIPTION
The numerical regression checking of `test_sampling.py` sometimes fails due to small numerical errors. This PR loosens the corresponding tolerances to make these tests pass more reliably.

Formatting with the new 23.1.0 version of black is also performed.