### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     'pytest',
     'pytest-regressions',
     'black',
-    'flake8<6.0.0',  # flake8 6.0.0 is currently incompatible with flake8-quotes
+    'flake8',
     'flake8-bugbear',
     'flake8-comprehensions',
     'flake8-quotes',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'e3nn-jax',
     'h5py',
     'hydra-core',
-    'jax[cuda]<0.4.2',
+    'jax[cuda]',
     'jaxtyping',
     'kfac-jax',
     'pyscf',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    'chex<0.1.6',  # TypeError: Subscripted generics cannot be used with class and instance checks
     'dm-haiku',
     'e3nn-jax',
     'h5py',


### PR DESCRIPTION
Fixes failing tests, caused by the new `chex` release.
Unpins the previously pinned dependecies of `jax<0.4.2` and `flake8<6.0.0`.