### PR TITLE
fix checkpoint of last performed step

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
     'show_toc_level': 1,
     'secondary_sidebar_items': [],
-    'footer_items': ['copyright', 'sphinx-version', 'theme-version', 'sourcelink'],
+    'footer_start': ['copyright', 'sphinx-version', 'theme-version', 'sourcelink'],
     'icon_links': [
         {
             'name': 'GitHub',

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -33,7 +33,7 @@ class CheckpointStore:
         self.buffer = None
 
     def update(self, step, state, loss=jnp.inf):
-        self.buffer = (step, loss, deepcopy(state))
+        self.buffer = (step, deepcopy(state), loss)
         if step > self.min_interval + (self.chkpts[-1].step if self.chkpts else 0) and (
             loss <= self.threshold * (self.chkpts[-1].loss if self.chkpts else jnp.inf)
         ):


### PR DESCRIPTION
The `train_state` of the last printed checkpoint was incorrect, due to a difference in the order of arguments of the `CheckpointStore.dump` method.