### PR TITLE
MERGE THIS FIRST -- [doc] fix docs warning about deprecated `footer_items`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
     'show_toc_level': 1,
     'secondary_sidebar_items': [],
-    'footer_items': ['copyright', 'sphinx-version', 'theme-version', 'sourcelink'],
+    'footer_start': ['copyright', 'sphinx-version', 'theme-version', 'sourcelink'],
     'icon_links': [
         {
             'name': 'GitHub',


### PR DESCRIPTION
Replace `footer_items` with `footer_start` in `doc/conf.py`.