### PR TITLE
remove deepcopy calls in pretrain and log

### DIFF
--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -1,6 +1,5 @@
 import pickle
 from collections import namedtuple
-from copy import deepcopy
 from pathlib import Path
 
 import jax.numpy as jnp
@@ -33,7 +32,7 @@ class CheckpointStore:
         self.buffer = None
 
     def update(self, step, state, loss=jnp.inf):
-        self.buffer = (step, deepcopy(state), loss)
+        self.buffer = (step, state, loss)
         if step > self.min_interval + (self.chkpts[-1].step if self.chkpts else 0) and (
             loss <= self.threshold * (self.chkpts[-1].loss if self.chkpts else jnp.inf)
         ):

--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -1,5 +1,4 @@
 import math
-from copy import deepcopy
 from functools import partial
 
 import haiku as hk
@@ -108,8 +107,8 @@ def pretrain(  # noqa: C901
             wf_state, params_new, opt_state_new, losses = _step(
                 rng,
                 wf_state,
-                deepcopy(params),
-                deepcopy(opt_state),
+                params,
+                opt_state,
                 phys_config,
             )
             wf_state, overflow = state_callback(wf_state)


### PR DESCRIPTION
We don't use the jax-kfac optimizer during pretraining, therefore making a copy of the params/opt_state is not necessary. Copying is also not necessary during logging, as the copied value is only used after the very last training step, therefore it cannot be overriden in subsequent iterations.