### PR TITLE
allow loading pseudopotentials for heavy atoms

### DIFF
--- a/src/deepqmc/wf/baseline/pyscfext.py
+++ b/src/deepqmc/wf/baseline/pyscfext.py
@@ -98,8 +98,8 @@ def parse_pp_params(mol):
         if mol.pp_mask[i]:
             _, data = gto.M(
                 atom=[(int(atomic_number), jnp.array([0, 0, 0]))],
+                # spin is just a placeholder, ecp parameters don't depend on the spin
                 spin=atomic_number % 2,
-                basis='6-31G',
                 ecp=mol.pp_type,
             )._ecp.popitem()
             pp_loc_param = data[1][0][1][1:4]


### PR DESCRIPTION
The basis specified in `gto.M()` caused errors when trying to load pseudopotential parameters for atoms heavier than Zn. Since the pseudopotential parameters are independent of the basis, a default basis can be used to avoid the `BasisNotFound` errors for larger atoms. The pseudopotentials are also independent of the spin, which is a required argument, and I have clarified it in the additional comment.