### PR TITLE
Reintroduce local energy logging

### DIFF
--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -329,10 +329,10 @@ def train(  # noqa: C901
                                 train_state,
                                 stats['per_mol']['E_loc/std'].mean(),
                             )
-                        for table, E, ewm_state, smpl_state in zip(
-                            tables, per_mol_energy, ewm_states, train_state.sampler
+                        for i, (table, ewm_state, smpl_state) in enumerate(
+                            zip(tables, ewm_states, train_state.sampler)
                         ):
-                            table.row['E_mean'] = E
+                            table.row['E_loc'] = E_loc[mol_idx == i]
                             if ewm_state.mean is not None:
                                 table.row['E_ewm'] = ewm_state.mean
                             table.row['sign_psi'] = smpl_state['psi'].sign

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -150,7 +150,7 @@ def train(  # noqa: C901
         h5file.swmr_mode = True
         tables = []
         for i, mol in enumerate(sampler.mols):
-            group = h5file.require_group(str(i))
+            group = h5file.require_group(str(i)) if len(sampler.mols) > 1 else h5file
             group.attrs.create('geometry', mol.coords.tolist())
             table = H5LogTable(group)
             table.resize(init_step)


### PR DESCRIPTION
This PR reintroduces the logging of the local energies. Furthermore, it removes the geometry keys from the `results.h5` file if the model is optimized for a single geometry.