### PR TITLE
restrict kfac-jax<0.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'jax[cuda]',
     'jaxtyping',
     'jax-dataclasses',
-    'kfac-jax',
+    'kfac-jax<0.0.5',
     'optax',
     'pyscf',
     'tensorboard',


### PR DESCRIPTION
The new 0.0.5 release of kfac-jax results in extremely slow compile times. Until this is investigated, we use the previous 0.0.3 version of kfac-jax.