### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DeepQMC implements variational quantum Monte Carlo for electrons in molecules, u
 Install and update to the latest release using [Pip](https://pip.pypa.io/en/stable/quickstart/):
 
 ```
-pip install -U deepqmc -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install -U deepqmc
 ```
 
 To install DeepQMC from a local Git repository run:
@@ -25,10 +25,22 @@ To install DeepQMC from a local Git repository run:
 ```
 git clone https://github.com/deepqmc/deepqmc
 cd deepqmc
-pip install -e .[dev] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install -e .[dev]
 ```
 
-If pip complains about `setup.py` not being found, please make sure to update to the latest pip version.
+If Pip complains about `setup.py` not being found, please update to the latest Pip version.
+
+The above installation will result in the CPU version of JAX. However, running DeepQMC on the GPU is highly recomended. To enable GPU support make sure to upgrade JAX to match the CUDA and cuDNN versions of your system. For most users this can be achieved with:
+
+```
+# CUDA 12 installation
+pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+# CUDA 11 installation
+pip install --upgrade "jax[cuda11_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+```
+
+If issues arise during the JAX installation visit the [JAX Install Guide](https://github.com/google/jax#installation).
 
 ### Documentation and exemplary usage
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
 [![doi](https://img.shields.io/badge/doi-10.5281%2Fzenodo.3960826-blue)](http://doi.org/10.5281/zenodo.3960826)
 
-DeepQMC implements variational quantum Monte Carlo for electrons in molecules, using deep neural networks as trial wave functions. The package is based on [JAX](https://github.com/google/jax) and [Haiku](https://github.com/deepmind/dm-haiku). Besides the core functionality, it contains an implementation of the [PauliNet](https://doi.org/ghcm5p) ansatz.
+DeepQMC implements variational quantum Monte Carlo for electrons in molecules, using deep neural networks as trial wave functions. The package is based on [JAX](https://github.com/google/jax) and [Haiku](https://github.com/deepmind/dm-haiku). Besides the core functionality, it contains an implementation of a flexible neural network wave function ansatz, that can be configured to obtain a broad range of molecular neural network wave functions. Config files for the instantiation of variants of [PauliNet](https://doi.org/10.1038/s41557-020-0544-y), [FermiNet](https://link.aps.org/doi/10.1103/PhysRevResearch.2.033429) and [DeepErwin](https://arxiv.org/abs/2205.09438) can be found under `src/deepqmc/conf/ansatz`.
 
-### Installing
+### Installation
 
-Install and update using [Pip](https://pip.pypa.io/en/stable/quickstart/):
+Install and update to the latest release using [Pip](https://pip.pypa.io/en/stable/quickstart/):
 
 ```
 pip install -U deepqmc -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
@@ -28,6 +28,28 @@ cd deepqmc
 pip install -e .[dev] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
+If pip complains about `setup.py` not being found, please make sure to update to the latest pip version.
+
 ### Documentation and exemplary usage
 
 For further information about the DeepQMC package and tutorials covering the basic usage visit the [documentation](https://deepqmc.github.io).
+
+### Citation
+
+This repository can be cited as:
+```
+@software{deepqmc,
+	author = {Jan Hermann and
+		  Zeno Schätzle and
+		  Peter Bernát Szabó and
+		  Matěj Mezera and
+		  {DeepQMC Contributers}},
+	title = {{DeepQMC}},
+	year = {2023},
+	publisher = {Zenodo},
+	copyright = {MIT},
+	url = {https://github.com/deepqmc/deepqmc},
+	doi = {10.5281/zenodo.7503172},
+}
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'dm-haiku',
     'h5py',
     'hydra-core',
-    'jax[cuda]',
+    'jax',
     'jaxtyping',
     'jax-dataclasses',
     'kfac-jax',


### PR DESCRIPTION
This PR updates the read me and sets the cpu version of jax as default. The upgrade to the GPU version is then done in a subsequent step. 