### PR TITLE
Make mols argument optional

### DIFF
--- a/src/deepqmc/conf/task/train.yaml
+++ b/src/deepqmc/conf/task/train.yaml
@@ -3,7 +3,6 @@ defaults:
 _target_: deepqmc.app.train_from_factories
 hamil: ${hamil}
 ansatz: ${ansatz}
-mols: ${hamil.mol}
 opt: kfac
 steps: 1000
 sample_size: 1000

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -53,14 +53,13 @@ def train(  # noqa: C901
     ansatz,
     opt,
     sampler,
-    mols,
-    workdir=None,
-    train_state=None,
-    init_step=0,
-    *,
     steps,
     sample_size,
     seed,
+    mols=None,
+    workdir=None,
+    train_state=None,
+    init_step=0,
     max_restarts=3,
     max_eq_steps=1000,
     pretrain_steps=None,
@@ -96,16 +95,17 @@ def train(  # noqa: C901
             - :data:`None`: no optimizer is used, e.g. the evaluation of the Ansatz
                 is performed.
         sampler (~deepqmc.sampling.Sampler): a sampler instance
-        mols (~deepqmc.molecule.Molecule): a molecule or a sequence of molecules to
-            consider.
+        steps (int): number of optimization steps.
+        sample_size (int): the number of samples considered in a batch
+        seed (int): the seed used for PRNG.
+        mols (Sequence(~deepqmc.molecule.Molecule)): optional, a sequence of molecules
+            to consider for transferable training. If None the default molecule from
+            hamil is used.
         workdir (str): optional, path, where results should be saved.
         train_state (~deepqmc.fit.TrainState): optional, training checkpoint to
             restore training or run evaluation.
         init_step (int): optional, initial step index, useful if
             calculation is restarted from checkpoint saved on disk.
-        steps (int): optional, number of optimization steps.
-        sample_size (int): the number of samples considered in a batch
-        seed (int): the seed used for PRNG.
         max_restarts (int): optional, the maximum number of times the training is
             retried before a :class:`NaNError` is raised.
         max_eq_steps (int): optional, maximum number of equilibration steps if not
@@ -129,6 +129,7 @@ def train(  # noqa: C901
 
     rng = jax.random.PRNGKey(seed)
     mode = 'evaluation' if opt is None else 'training'
+    mols = mols or hamil.mol
     sampler = MultimoleculeSampler(sampler, mols, mol_idx_factory)
     if isinstance(opt, str):
         opt_kwargs = OPT_KWARGS.get(opt, {}) | (opt_kwargs or {})


### PR DESCRIPTION
The `mols` argument of the `train` function only makes sense in the context of the (undocumented) transferable training and should therefor be optional in the single point calculation setting. If we happen to fully adapt the `hydra` initialization also for the training runs eventually, this would become obsolete.