### PR TITLE
temporarily restrict jax<0.4.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     'h5py',
     'hydra-core',
     'jax<0.4.11',
+    'jaxlib<0.4.11',
     'jaxtyping',
     'jax-dataclasses',
     'kfac-jax',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'dm-haiku',
     'h5py',
     'hydra-core',
-    'jax',
+    'jax<0.4.11',
     'jaxtyping',
     'jax-dataclasses',
     'kfac-jax',


### PR DESCRIPTION
KFAC==0.0.5 is incompatible with jax=0.4.11. Until this is fixed upstream, we should use compatible versions.