### PR TITLE
add configs for SAML training

### DIFF
--- a/src/deepqmc/conf/task/sampler/langevin_saml.yaml
+++ b/src/deepqmc/conf/task/sampler/langevin_saml.yaml
@@ -1,0 +1,6 @@
+- _target_: deepqmc.sampling.DecorrSampler
+  length: 50
+- _target_: deepqmc.sampling.LangevinSampler
+  _partial_: true
+  tau: 1.0
+  max_age: 50

--- a/src/deepqmc/conf/task/sampler/metropolis_saml.yaml
+++ b/src/deepqmc/conf/task/sampler/metropolis_saml.yaml
@@ -1,0 +1,6 @@
+- _target_: deepqmc.sampling.DecorrSampler
+  length: 100
+- _target_: deepqmc.sampling.MetropolisSampler
+  _partial_: true
+  tau: 1.0
+  max_age: 100

--- a/src/deepqmc/conf/task/train_saml.yaml
+++ b/src/deepqmc/conf/task/train_saml.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - sampler: langevin_saml
+  - opt: kfac
+_target_: deepqmc.app.train_from_factories
+hamil: ${hamil}
+ansatz: ${ansatz}
+steps: 50000
+sample_size: 2048
+seed: 0
+pretrain_steps: 5000
+pretrain_kwargs:
+  baseline_kwargs:
+    basis: 6-311G
+fit_kwargs:
+  clip_mask_fn:
+    _target_: deepqmc.fit.median_clip_and_mask
+    _partial_: true
+    clip_width: 5.0
+    median_center: false


### PR DESCRIPTION
To use the SAML config from the CLI:
```
deepqmc task=train_saml
```

To use the SAML config with the Metropolis sampler:
```
deepqmc task=train_saml task/sampler=metropolis_saml
```