### PR TITLE
fix full determinant pretrain for n_up != n_down

### DIFF
--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -62,7 +62,7 @@ def pretrain(  # noqa: C901
                 ),
                 jnp.concatenate(
                     (
-                        jnp.zeros((*target[1].shape[:-1], n_down)),
+                        jnp.zeros((*target[1].shape[:-1], n_up)),
                         target[1],
                     ),
                     axis=-1,


### PR DESCRIPTION
When concatenating the target orbitals with zeros, the spin up target should be concatenated with zeros of shape `[batch_size, n_det, n_up, n_down]` and not `[batch_size, n_det, n_up, n_up]` as it was previously.

Same for spin down target.

Moreover, the different spin cases cannot be summed before the electron dimension has been reduced, because `n_up != n_down` is possible.

I'm mimicing `deeperwin` in that the final loss is computed as `loss_up.mean() + loss_down.mean()`. FermiNet does the same if `full_determinant=False`, and for full determinants it computes the proper mean over all electrons.