### PR TITLE
fix chained restarts

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -54,9 +54,9 @@ def train_from_checkpoint(workdir, restdir, evaluate, chkpt='LAST', **kwargs):
         raise ValueError(f'restdir {restdir!r} is not a directory')
     cfg, step, train_state = task_from_workdir(restdir, chkpt)
     while cfg.task.get('restdir', False):
-        prev_restdir = Path(to_absolute_path(get_original_cwd())) / cfg.task.restdir
-        cfg, *_ = task_from_workdir(prev_restdir, chkpt)
-    log.info(f'Found original config file in {prev_restdir}')
+        restdir = Path(to_absolute_path(get_original_cwd())) / cfg.task.restdir
+        cfg, *_ = task_from_workdir(restdir, chkpt)
+    log.info(f'Found original config file in {restdir}')
     cfg.task.workdir = workdir
     if evaluate:
         cfg.task.opt = None


### PR DESCRIPTION
When a run is restarted multiple times, the original config file can be found in the workdir of the very first run. In such a case we follow the runs backwards, looking in the `restdir` of each of them, until we find a run that doesn't have a `restdir`, which is assumed to be the first run we are looking for.