### PR TITLE
turn off nucleus-electron edges for default ansatz

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -53,6 +53,10 @@ def train_from_checkpoint(workdir, restdir, evaluate, chkpt='LAST', **kwargs):
     if not restdir.is_dir():
         raise ValueError(f'restdir {restdir!r} is not a directory')
     cfg, step, train_state = task_from_workdir(restdir, chkpt)
+    while cfg.task.get('restdir', False):
+        prev_restdir = Path(to_absolute_path(get_original_cwd())) / cfg.task.restdir
+        cfg, *_ = task_from_workdir(prev_restdir, chkpt)
+    log.info(f'Found original config file in {prev_restdir}')
     cfg.task.workdir = workdir
     if evaluate:
         cfg.task.opt = None

--- a/src/deepqmc/conf/ansatz/default.yaml
+++ b/src/deepqmc/conf/ansatz/default.yaml
@@ -60,7 +60,6 @@ omni_factory:
     edge_types:
     - same
     - anti
-    - ne
     edge_features:
       same:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature

--- a/src/deepqmc/conf/ansatz/default.yaml
+++ b/src/deepqmc/conf/ansatz/default.yaml
@@ -54,7 +54,7 @@ omni_factory:
     _target_: deepqmc.gnn.ElectronGNN
     _partial_: true
     n_interactions: 3
-    positional_electron_embeddings: false
+    positional_electron_embeddings: true
     atom_type_embeddings: true
     two_particle_stream_dim: 32
     edge_types:
@@ -116,5 +116,4 @@ omni_factory:
       - node_down
       - edge_same
       - edge_anti
-      - edge_ne
   


### PR DESCRIPTION
Use `positional_electron_embeddings=true` instead.