### PR TITLE
restrict scipy<1.11.0 due to sym_pos arg of linalg.solve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     'kfac-jax',
     'optax',
     'pyscf',
+    'scipy<1.11.0',
     'tensorboard',
     'pyyaml',
     'tqdm',


### PR DESCRIPTION
Let's wait for the tests to finish to see if this fixes the issue.