### PR TITLE
add FermiNet train and sampler configs

### DIFF
--- a/src/deepqmc/conf/task/sampler/decorr_metropolis_ferminet.yaml
+++ b/src/deepqmc/conf/task/sampler/decorr_metropolis_ferminet.yaml
@@ -3,4 +3,5 @@
 - _target_: deepqmc.sampling.MetropolisSampler
   _partial_: true
   tau: 0.02
+  target_acceptance: 0.525
   max_age: null

--- a/src/deepqmc/conf/task/train_ferminet.yaml
+++ b/src/deepqmc/conf/task/train_ferminet.yaml
@@ -8,6 +8,15 @@ mols: ${hamil.mol}
 steps: 100000
 sample_size: 4096
 seed: 0
+pretrain_steps: 1000
+pretrain_kwargs:
+  opt: adam
+  opt_kwargs:
+    learning_rate: 3.e-4
+    b1: 0.9
+    b2: 0.999
+  baseline_kwargs:
+    basis: sto-6g
 fit_kwargs:
   clip_mask_fn:
     _target_: deepqmc.fit.median_clip_and_mask


### PR DESCRIPTION
These configs should match the FermiNet training and sampling hyperparameters.

The FermiNet sampler is still slightly different from ours:

1. `tau` is adapted only every 100th training step
2. The target acceptance rate is between 0.5 and 0.55
3. The acceptance rate is calculated as the average acceptance rate over the last 100 training steps

These should be minor enough for now, but we should not forget about this.