### PR TITLE
fix NaN errors for pseudopotentials

### DIFF
--- a/src/deepqmc/physics.py
+++ b/src/deepqmc/physics.py
@@ -113,7 +113,9 @@ def get_quadrature_points(rng, nucleus_position, phys_conf):
 
     N = len(phys_conf)
     norm = jnp.linalg.norm(phys_conf.r - nucleus_position, axis=-1)
-    theta = jnp.arccos((phys_conf.r - nucleus_position)[..., 2] / norm)
+    theta = jnp.arccos(
+        jnp.clip((phys_conf.r - nucleus_position)[..., 2] / norm, a_min=-1.0, a_max=1.0)
+    )
     phi = jnp.arctan2(
         (phys_conf.r - nucleus_position)[..., 1],
         (phys_conf.r - nucleus_position)[..., 0],


### PR DESCRIPTION
The argument of `arccos` could rarely overflow the interval `[-1,1]` interval due to numerical rounding errors. This caused a NaN and a subsequent crash of the training (or restart from checkpoint). The `jnp.clip` function should fix this.