### PR TITLE
disable TensorFloat32

### DIFF
--- a/src/deepqmc/__init__.py
+++ b/src/deepqmc/__init__.py
@@ -1,9 +1,35 @@
+import logging
+import os
+import sys
+
 from omegaconf import OmegaConf
 
-from .hamil import MolecularHamiltonian
-from .molecule import Molecule
-from .sampling import DecorrSampler, MetropolisSampler, ResampledSampler
-from .train import train
+log = logging.getLogger(__name__)
+
+if not os.environ.get('NVIDIA_TF32_OVERRIDE'):
+    # disable TensorFloat-32 for better precision
+    os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+    if 'jax' in sys.modules:
+        log.warning(
+            'JAX was imported before deepqmc, TensorFloat32 precision might be enabled.'
+            ' You may experience numerical issues.'
+        )
+elif os.environ.get('NVIDIA_TF32_OVERRIDE') != '0':
+    log.warning(
+        'TensorFloat-32 seems to be enabled. You might want to disable TensorFloat-32'
+        ' precision by setting NVIDIA_TF32_OVERRIDE=0 before loading deepqmc to avoid'
+        ' numerical issues.'
+    )
+
+
+from .hamil import MolecularHamiltonian  # noqa: E402
+from .molecule import Molecule  # noqa: E402
+from .sampling import (  # noqa: E402
+    DecorrSampler,
+    MetropolisSampler,
+    ResampledSampler,
+)
+from .train import train  # noqa: E402
 
 OmegaConf.register_new_resolver('eval', eval)
 


### PR DESCRIPTION
Warn the user if TensorFloat32 might be turned on. This warning may not be shown in some edge cases but should be sufficient for regular users.

Closes #97