### PR TITLE
pseudopotentials minor fixes

### DIFF
--- a/src/deepqmc/hamil/qc.py
+++ b/src/deepqmc/hamil/qc.py
@@ -43,9 +43,10 @@ class MolecularHamiltonian(Hamiltonian):
     Args:
         mol (~deepqmc.Molecule): the molecule to consider
         pp_type (str): If set, use the appropriate pseudopotential. The string is passed
-            to :func:`pyscf.gto.M()` as :data:`'ecp'` argument. Currently supported
-            pseudopotential types: :data:`'bfd'` [Burkatzki et al. 2007],
-            :data:`'ccECP'` [Bennett et al. 2017]. Other types might not work properly.
+            to :func:`pyscf.gto.M()` as :data:`'ecp'` argument. Supports
+            pseudopotentials that are implemented in the pyscf package, e.g.
+            :data:`'bfd'` [Burkatzki et al. 2007] or :data:`'ccECP'`
+            [Bennett et al. 2017].
         pp_mask (list, (:math:`N_\text{nuc}`)): list of True and False values specifying
             whether to use a pseudopotential for each nucleus
         elec_std (float): optional, a default value of the scaling factor

--- a/src/deepqmc/pp/ecp_potential.py
+++ b/src/deepqmc/pp/ecp_potential.py
@@ -34,14 +34,19 @@ def parse_ecp_type_params(charges, pp_type, pp_mask):
     max_number_of_same_type_terms = []
     for i, atomic_number in enumerate(charges):
         if pp_mask[i]:
-            _, data = gto.M(
+            pyscf_mole = gto.M(
                 atom=[(int(atomic_number), jnp.array([0, 0, 0]))],
                 # spin is just a placeholder, ecp parameters don't depend on the spin
                 spin=atomic_number % 2,
                 ecp=pp_type,
-            )._ecp.popitem()
+            )
+            assert len(pyscf_mole._ecp) == 1, (
+                f'Pseudopotential of type {pp_type} not found for'
+                f' {pyscf_mole._atom[0][0]} atom.'
+            )
+            _, data = pyscf_mole._ecp.popitem()
             pp_loc_param = data[1][0][1][1:4]
-            if data[0] != 0:
+            if len(data[1]) > 1:
                 pp_nl_param = jnp.array([di[1][2] for di in data[1][1:]]).swapaxes(
                     -1, -2
                 )

--- a/src/deepqmc/pp/ecp_potential.py
+++ b/src/deepqmc/pp/ecp_potential.py
@@ -79,9 +79,9 @@ def parse_ecp_type_params(charges, pp_type, pp_mask):
 class EcpTypePseudopotential(Potential):
     r"""Class for the pseudopotential of the ECP type.
 
-    Supports both 'ccECP' and 'bfd' pseudopotentials. The pseudopotential parameters
-    are loaded from the pyscf package.
-    The pseudopotential is defined by the general formula:
+    Supports pseudopotentials that are defined in pyscf package, such as 'bfd', 'ccECP',
+    'ccECP_reg' or 'ccECP_He'. The pseudopotential parameters are loaded directly from
+    the pyscf package. The pseudopotential is defined by the general formula:
     :math: `\sum_{l=0}^{l_\text{max}} V_{\text{nl}}(\mathbf{r}) |lm\rangle\langle lm|`
     :math: V_\text{nl}({r}) = \sum_{k=1}^{2} \beta_{lk} \text{e}^{-\alpha_k r^2}
     """
@@ -217,8 +217,12 @@ class EcpTypePseudopotential(Potential):
             )
             return val + nl_potential_for_one_nucleus
 
-        total_nl_potential = jax.lax.fori_loop(
-            0, len(self.nuc_with_nl_pot), add_nl_potential_for_one_nucleus, 0.0
+        total_nl_potential = (
+            jax.lax.fori_loop(
+                0, len(self.nuc_with_nl_pot), add_nl_potential_for_one_nucleus, 0.0
+            )
+            if len(self.nuc_with_nl_pot) > 0
+            else 0.0
         )
 
         return total_nl_potential


### PR DESCRIPTION
The jitting would crash if no non-local part was present in the pseudopotential. This only affects some edge cases like the He atom with pseudopotential. This PR also clarifies what types of pseudopotentials can be used in some docstrings and improves error handling.