### PR TITLE
improve device detection functionality

### DIFF
--- a/src/deepqmc/conf/config.yaml
+++ b/src/deepqmc/conf/config.yaml
@@ -14,7 +14,6 @@ hydra:
     - file://conf
 task:
   workdir: ???
-device: cuda
 logging:
   deepqmc: 20
   jax: 40

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,6 @@ class TestApp:
     ARGS = [
         'deepqmc',
         'hamil/mol=H2',
-        'device=cpu',
         'task.steps=1',
         'task.electron_batch_size=2',
         '+task.max_eq_steps=1',


### PR DESCRIPTION
Improve the log message of the utilized devices.

Since the selection of the used device through the CLI was not functional in the current version, and it would be very rarely used, this config option is removed.