### PR TITLE
refactor parallel utils for more efficient pmaps

### DIFF
--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -222,7 +222,7 @@ def fit_wf(  # noqa: C901
         return sampler.update(state, partial(ansatz.apply, params))
 
     def train_step(rng, step, smpl_state, params, opt_state):
-        rng_sample, rng_kfac = split_on_devices(rng)
+        rng_sample, rng_kfac = split_on_devices(rng, 2)
         mol_idxs = molecule_idx_sampler.sample()
         smpl_state, phys_conf, smpl_stats = sample_wf(
             smpl_state, rng_sample, params, mol_idxs

--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -93,7 +93,7 @@ def pretrain(  # noqa: C901
     else:
         raise NotImplementedError
 
-    rng, rng_smpl_init = split_on_devices(split_rng_key_to_devices(rng))
+    rng, rng_smpl_init = split_on_devices(split_rng_key_to_devices(rng), 2)
     wf = partial(ansatz.apply, select_one_device(params))
     sample_initializer = partial(
         sampler.init,


### PR DESCRIPTION
Calling `pmap` in loops should be avoided. With this refactor, `pmap` is applied to the utility functions in `parallel.py` as a decorator. This avoids repeatedly compiling code in loops.