### PR TITLE
explicitly pass `params` to sampling function

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -68,7 +68,7 @@ def train_from_factories(hamil, ansatz, sampler, **kwargs):
     from .train import train
 
     ansatz = instantiate_ansatz(hamil, ansatz)
-    sampler = chain(*sampler[:-1], sampler[-1](hamil))
+    sampler = chain(*sampler[:-1], sampler[-1](hamil, ansatz.apply))
     return train(hamil, ansatz, sampler=sampler, **kwargs)
 
 

--- a/src/deepqmc/fit.py
+++ b/src/deepqmc/fit.py
@@ -222,7 +222,7 @@ def fit_wf(  # noqa: C901
         return sampler.update(state, partial(ansatz.apply, params))
 
     def train_step(rng, step, smpl_state, params, opt_state):
-        rng_sample, rng_kfac = split_on_devices(rng)
+        rng_sample, rng_kfac = split_on_devices(rng, 2)
         mol_idxs = molecule_idx_sampler.sample()
         smpl_state, phys_conf, smpl_stats = sample_wf(
             smpl_state, rng_sample, params, mol_idxs

--- a/src/deepqmc/hamil/qc.py
+++ b/src/deepqmc/hamil/qc.py
@@ -104,6 +104,7 @@ class MolecularHamiltonian(Hamiltonian):
             n (int): the number of configurations to generate.
                 electrons around the nuclei.
         """
+        assert R.ndim == 2
 
         Rs = jnp.tile(R[None], (n, 1, 1))
         return vmap(self.init_single_sample, (0, 0, None))(

--- a/src/deepqmc/hamil/qc.py
+++ b/src/deepqmc/hamil/qc.py
@@ -87,7 +87,7 @@ class MolecularHamiltonian(Hamiltonian):
             get_shell(z + 1) - 1 for z in self.mol.charges - self.ns_valence
         ]
 
-    def init_sample(self, rng, Rs, n, elec_std=None):
+    def init_sample(self, rng, R, n, elec_std=None):
         r"""
         Guess some initial electron positions.
 
@@ -99,13 +99,13 @@ class MolecularHamiltonian(Hamiltonian):
 
         Args:
             rng (jax.random.PRNGKey): key used for PRNG.
-            Rs (float, (:data:`n`, :math:`N_\text{nuc}`, 3)): nuclear coordinates,
-                it is broadcasted if batch dimension (:data:`n`) is omitted
+            R (float, (:math:`N_\text{nuc}`, 3)): nuclear coordinates of a single
+                molecular geometry
             n (int): the number of configurations to generate.
                 electrons around the nuclei.
         """
 
-        Rs = jnp.tile(Rs[None], (n, 1, 1)) if Rs.ndim == 2 else Rs
+        Rs = jnp.tile(R[None], (n, 1, 1))
         return vmap(self.init_single_sample, (0, 0, None))(
             random.split(rng, n), Rs, elec_std
         )

--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -93,7 +93,7 @@ def pretrain(  # noqa: C901
     else:
         raise NotImplementedError
 
-    rng, rng_smpl_init = split_on_devices(split_rng_key_to_devices(rng))
+    rng, rng_smpl_init = split_on_devices(split_rng_key_to_devices(rng), 2)
     wf = partial(ansatz.apply, select_one_device(params))
     sample_initializer = partial(
         sampler.init,

--- a/src/deepqmc/pretrain.py
+++ b/src/deepqmc/pretrain.py
@@ -94,18 +94,14 @@ def pretrain(  # noqa: C901
         raise NotImplementedError
 
     rng, rng_smpl_init = split_on_devices(split_rng_key_to_devices(rng), 2)
-    wf = partial(ansatz.apply, select_one_device(params))
-    sample_initializer = partial(
-        sampler.init,
-        wf=wf,
-        electron_batch_size=electron_batch_size // jax.device_count(),
+    smpl_state = jax.pmap(sampler.init, static_broadcasted_argnums=2)(
+        rng_smpl_init, params, electron_batch_size // jax.device_count()
     )
-    smpl_state = jax.pmap(sample_initializer)(rng_smpl_init)
 
     opt_state = jax.pmap(opt.init)(params)
 
     def sample_wf(state, rng, params, idxs):
-        return sampler.sample(rng, state, partial(ansatz.apply, params), idxs)
+        return sampler.sample(rng, state, params, idxs)
 
     @partial(jax.pmap, axis_name='device_axis')
     def pretrain_step(rng, params, smpl_state, opt_state, mol_idxs):


### PR DESCRIPTION
Previously the sampling functions `init`, `sample`, etc. received the parameters implicitly with `wf=partial(ansatz.apply, params)`.

However, explicitly passing `params` allows for less cumbersome `jax` function transformations.