### PR TITLE
fix psiformer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'dm-haiku',
+    'dm-haiku>0.0.9',
     'h5py',
     'hydra-core',
     'jax',

--- a/src/deepqmc/conf/ansatz/deeperwin.yaml
+++ b/src/deepqmc/conf/ansatz/deeperwin.yaml
@@ -55,7 +55,7 @@ omni_factory:
       positional_embeddings:
         ne:
           _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-          edge_features:
+          features:
           - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
             powers: [1]
           - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
@@ -66,7 +66,7 @@ omni_factory:
     edge_features:
       ne:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature

--- a/src/deepqmc/conf/ansatz/default.yaml
+++ b/src/deepqmc/conf/ansatz/default.yaml
@@ -71,7 +71,7 @@ omni_factory:
       positional_embeddings:
         ne:
           _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-          edge_features:
+          features:
           - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
             powers: [1]
           - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
@@ -82,13 +82,13 @@ omni_factory:
     edge_features:
       same:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
       anti:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature

--- a/src/deepqmc/conf/ansatz/ferminet.yaml
+++ b/src/deepqmc/conf/ansatz/ferminet.yaml
@@ -47,7 +47,7 @@ omni_factory:
       positional_embeddings:
         ne:
           _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-          edge_features:
+          features:
           - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
             powers: [1]
           - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
@@ -59,13 +59,13 @@ omni_factory:
     edge_features:
       up:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
       down:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature

--- a/src/deepqmc/conf/ansatz/psiformer.yaml
+++ b/src/deepqmc/conf/ansatz/psiformer.yaml
@@ -66,7 +66,7 @@ omni_factory:
       project_to_embedding_dim: true
     two_particle_stream_dim: 32
     self_interaction: true
-    edge_features: []
+    edge_features: null
     layer_factory:
       _target_: deepqmc.gnn.electron_gnn.ElectronGNNLayer
       _partial_: true

--- a/src/deepqmc/conf/ansatz/psiformer.yaml
+++ b/src/deepqmc/conf/ansatz/psiformer.yaml
@@ -56,7 +56,7 @@ omni_factory:
       positional_embeddings:
         ne:
           _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-          edge_features:
+          features:
           - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
             powers: [1]
             log_rescale: true

--- a/src/deepqmc/gnn/edge_features.py
+++ b/src/deepqmc/gnn/edge_features.py
@@ -83,15 +83,15 @@ class CombinedEdgeFeature(EdgeFeature):
     r"""Combine multiple edge features.
 
     Args:
-        edge_features (Sequence): a :data:`Sequence` of edge feature objects
+        features (Sequence): a :data:`Sequence` of edge feature objects
             to combine.
     """
 
-    def __init__(self, *, edge_features):
-        self.edge_features = edge_features
+    def __init__(self, *, features):
+        self.features = features
 
     def __call__(self, d):
-        return jnp.concatenate([ef(d) for ef in self.edge_features], axis=-1)
+        return jnp.concatenate([f(d) for f in self.features], axis=-1)
 
     def __len__(self):
-        return sum(map(len, self.edge_features))
+        return sum(map(len, self.features))

--- a/src/deepqmc/gnn/electron_gnn.py
+++ b/src/deepqmc/gnn/electron_gnn.py
@@ -272,7 +272,7 @@ class ElectronGNN(hk.Module):
                 'electrons': jnp.array(n_up * [0] + n_down * [int(n_up != n_down)])
             },
         }
-        self.edge_types = tuple(edge_features.keys())
+        self.edge_types = tuple((edge_features or {}).keys())
         self.layers = [
             layer_factory(
                 n_interactions,

--- a/tests/conf/ansatz.yaml
+++ b/tests/conf/ansatz.yaml
@@ -84,19 +84,19 @@ omni_factory:
     edge_features:
       same:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
       anti:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
       ne:
         _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-        edge_features:
+        features:
         - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
           powers: [1]
         - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature

--- a/tests/conf/gnn.yaml
+++ b/tests/conf/gnn.yaml
@@ -18,19 +18,19 @@ self_interaction: false
 edge_features:
   ne:
     _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-    edge_features:
+    features:
     - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
       powers: [1]
     - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
   same:
     _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-    edge_features:
+    features:
     - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
       powers: [1]
     - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature
   anti:
     _target_: deepqmc.gnn.edge_features.CombinedEdgeFeature
-    edge_features:
+    features:
     - _target_: deepqmc.gnn.edge_features.DistancePowerEdgeFeature
       powers: [1]
     - _target_: deepqmc.gnn.edge_features.DifferenceEdgeFeature


### PR DESCRIPTION
This PR fixes a small bug in the Psiformer config file.

It also renames `CombinedEdgeFeatures.edge_features` to `CombinedEdgeFeatures.features` to avoid the following config structure:
```yaml
edge_features:
  up:
    _target_: ...
    edge_features: ...
```
And arrive at this one:
```yaml
edge_features:
  up:
    _target_: ...
    features: ...
```