### PR TITLE
use python3.11 in flake8 GitHub action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.11
       - name: Install dependencies
         run: pip install 'flake8' flake8-bugbear flake8-comprehensions flake8-quotes pep8-naming
       - uses: actions/checkout@v2

--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -155,8 +155,8 @@ def detect_devices():
     n_process = jax.process_count()
     log.info(
         'Running on'
-        f' {n_device} {device_kinds[0].upper()}{"" if n_device == 1 else "s"} with'  # noqa: Q000
-        f' {n_process} process{"" if n_process == 1 else "es"}'  # noqa: Q000
+        f' {n_device} {device_kinds[0].upper()}{"" if n_device == 1 else "s"} with'
+        f' {n_process} process{"" if n_process == 1 else "es"}'
     )
 
 


### PR DESCRIPTION


The syntax of f-strings has changed quite a bit from python 3.11 to 3.12, leading to a number of new flake8 warnings on our f-strings when flake8 is run in GitHub actions with the newest python 3.12 version.

Some of the changes required to get rid of these warnings would break the old (<= python 3.11) f-string syntax. Since most of us still use these older python versions, it makes the most sense to simply restrict our flake8 GitHub action to use python 3.11.
