### PR TITLE
move the hydra output subdirectory to one of our subdirs (`training`/`evaluation`)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.11
       - name: Install dependencies
         run: pip install 'flake8' flake8-bugbear flake8-comprehensions flake8-quotes pep8-naming
       - uses: actions/checkout@v2

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -32,11 +32,11 @@ This creates several files in the working directory, including:
 
 The training can be continued or recoverd from a training checkpoint::
 
-    $ deepqmc task=restart task.restdir=workdir
+    $ deepqmc task=restart task.restdir=workdir/training
 
 The evaluation of the energy of a trained wavefunction ansatz is obtained via::
 
-    $ deepqmc task=evaluate task.restdir=workdir
+    $ deepqmc task=evaluate task.restdir=workdir/training
 
 This again generates a Tensorboard event file ``evaluation/events.out.tfevents.*`` and an HDF5 file ``evaluation/result.h5`` file holding the sampled local energies.
 

--- a/src/deepqmc/__init__.py
+++ b/src/deepqmc/__init__.py
@@ -22,6 +22,7 @@ elif os.environ.get('NVIDIA_TF32_OVERRIDE') != '0':
     )
 
 
+from .conf.custom_resolvers import get_hydra_subdir  # noqa: E402
 from .hamil import MolecularHamiltonian  # noqa: E402
 from .molecule import Molecule  # noqa: E402
 from .sampling import (  # noqa: E402
@@ -32,6 +33,7 @@ from .sampling import (  # noqa: E402
 from .train import train  # noqa: E402
 
 OmegaConf.register_new_resolver('eval', eval)
+OmegaConf.register_new_resolver('get_hydra_subdir', get_hydra_subdir)
 
 __all__ = [
     'DecorrSampler',

--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -102,7 +102,7 @@ def task_from_workdir(workdir, chkpt):
 
     workdir = Path(workdir)
     assert workdir.is_dir()
-    cfg = OmegaConf.load(workdir / '.hydra/config.yaml')
+    cfg = OmegaConf.load(workdir / '.hydra' / 'config.yaml')
     if chkpt == 'LAST':
         chkpts = list(workdir.glob(CheckpointStore.PATTERN.format('*')))
         if not chkpts:

--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -155,8 +155,8 @@ def detect_devices():
     n_process = jax.process_count()
     log.info(
         'Running on'
-        f' {n_device} {device_kinds[0].upper()}{"" if n_device == 1 else "s"} with'  # noqa: Q000
-        f' {n_process} process{"" if n_process == 1 else "es"}'  # noqa: Q000
+        f' {n_device} {device_kinds[0].upper()}{"" if n_device == 1 else "s"} with'
+        f' {n_process} process{"" if n_process == 1 else "es"}'
     )
 
 

--- a/src/deepqmc/conf/config.yaml
+++ b/src/deepqmc/conf/config.yaml
@@ -12,6 +12,7 @@ hydra:
     chdir: true
   searchpath:
     - file://conf
+  output_subdir: ${get_hydra_subdir:}
 task:
   workdir: ???
 logging:

--- a/src/deepqmc/conf/config_slurm.yaml
+++ b/src/deepqmc/conf/config_slurm.yaml
@@ -12,6 +12,7 @@ hydra:
     chdir: true
   searchpath:
     - file://conf
+  output_subdir: ${get_hydra_subdir:}
   sweep:
     subdir: ${hydra.job.override_dirname}
 task:

--- a/src/deepqmc/conf/custom_resolvers.py
+++ b/src/deepqmc/conf/custom_resolvers.py
@@ -1,0 +1,12 @@
+import os
+
+from omegaconf import Container
+from omegaconf._impl import select_value
+
+__all__ = ()
+
+
+def get_hydra_subdir(_root_: Container) -> str:
+    evaluate = select_value(_root_, 'task.evaluate', default=False)
+    subdir = 'evaluation' if evaluate else 'training'
+    return os.path.join(subdir, '.hydra')


### PR DESCRIPTION
This way Ansatzes can be evaluated in the same directory as the training job was done.

For example the following is now possible:
```bash
$ deepqmc hydra.run.dir=run0
...
$ deepqmc task=evaluate task.restdir=run0/training hydra.run.dir=run0
```
**Note:** `task.restdir` now additionally expects the subdirectory, i.e. `run0/training` instead of the old `run0`.

The above jobs will only use the `run0` working directory, with its `training` subdirectory containing checkpoints and results for the training run, and its `evaluation` subdirectory containing results from the evaluation run. The `run0/deepqmc.log` log file will contain the concatenation of the training and evaluation logs.