### PR TITLE
increase jax matmul precision

### DIFF
--- a/src/deepqmc/__init__.py
+++ b/src/deepqmc/__init__.py
@@ -22,6 +22,8 @@ elif os.environ.get('NVIDIA_TF32_OVERRIDE') != '0':
     )
 
 
+import jax  # noqa: E402
+
 from .conf.custom_resolvers import get_hydra_subdir  # noqa: E402
 from .hamil import MolecularHamiltonian  # noqa: E402
 from .molecule import Molecule  # noqa: E402
@@ -32,6 +34,7 @@ from .sampling import (  # noqa: E402
 )
 from .train import train  # noqa: E402
 
+jax.config.update('jax_default_matmul_precision', 'highest')
 OmegaConf.register_new_resolver('eval', eval)
 OmegaConf.register_new_resolver('get_hydra_subdir', get_hydra_subdir)
 


### PR DESCRIPTION
This PR increases the default precision that JAX uses for matrix multiplication. This helps to improve the performance consistency across different GPU types. It also fixes the issue of unphysically low energies we observed on A100 gpus. 

I've encountered an issue where DeepQMC produces unphysical energies, sometimes as much as 20 mHa lower than the reference energies. I've only seen this issue on A100 GPUs, and the same scripts gave correct results when running on RTX3090. So at first I thought it was caused by the inaccurate `TensorFloat32` format used by the A100, but those TensorFloats are automatically disabled in our code ([here](https://github.com/deepqmc/deepqmc/blob/16cb5db0f5b26a05db8572d18e0991613237583a/src/deepqmc/__init__.py#L9-L22)).

I only saw the discrepancy between different GPUs when pseudopotentials were turned on, and I've narrowed it down to the local energy computation. While I haven't found the exact origin of the problem, I was able to find a simple fix, which is to increase the default precision of jax's matrix multiplication
`jax.config.update("jax_default_matmul_precision", "highest")`
In principle, the precision could be increased only for the part of the code where the numerical inaccuracy comes from to save the compute cost. But I increased the precision globally and observed only about 2% - 3% slowdown on A100. So I think it's better to run the computations with the highest possible precision just to be safe, especially on A100s.

![image](https://github.com/deepqmc/deepqmc/assets/18701830/955ca693-fb61-44aa-a855-95a4c9a59fd0)

This plot shows the training energy curve computed on A100, and restarted after 50k steps on

1. A100
2. RTX3090
3. A100 with increased precision

The black line is the reference energy, which is supposed to stay bellow the training energies. It shows that the energies return to the physical region when the highest jax precision was turned on (or when using a different gpu).

**This issue is prominent for systems with pseudopotentials, so it might be interesting to check if the discrepancy originates from the laplacian or from the nonlocal energy computation.**