### PR TITLE
fix installation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,15 @@ dependencies = [
     'jax<0.4.24',
     'jaxlib<0.4.24',
     'jax-dataclasses',
-    'kfac-jax',
+    'kfac-jax<0.0.6',
+    'scipy<1.12',
     'optax',
     'pyscf',
     'tensorboard',
     'pyyaml',
     'tqdm',
     'uncertainties',
+    'numpy<2.0.0'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR provides a new `pyproject.toml` which restricts the versions of the deepqmc dependencies to be compatible.

With this PR a fresh installation can be done in one(two) steps:

First install the deepqmc package and its dependencies:
`$ pip install -e .[dev]`

Optional: upgrade jax to obtain gpu support, i.e.:
`$ pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html`