### PR TITLE
fix logging code version when not using git

### DIFF
--- a/src/deepqmc/app.py
+++ b/src/deepqmc/app.py
@@ -1,5 +1,6 @@
 import logging
 import platform
+import re
 import sys
 import warnings
 from pathlib import Path
@@ -139,17 +140,18 @@ def maybe_log_code_version():
     if log.isEnabledFor(logging.DEBUG):
         import subprocess
 
-        def git_command(command):
-            return (
-                subprocess.check_output(
-                    ['git'] + command, cwd=Path(__file__).resolve().parent
-                )
-                .strip()
-                .decode()
-            )
+        cwd = Path(__file__).resolve().parent
 
-        sha = git_command(['rev-parse', '--short', 'HEAD'])
-        diff = git_command(['diff'])
+        def git_command(command):
+            return subprocess.check_output(['git'] + command, cwd=cwd).strip().decode()
+
+        try:
+            sha = git_command(['rev-parse', '--short', 'HEAD'])
+            diff = git_command(['diff'])
+        except Exception:
+            with open(cwd.parent.parent / Path('pyproject.toml')) as f:
+                sha = 'deepqmc ' + re.findall("version = '([.\0-9]*)'", f.read())[0]
+            diff = None
         log.debug(f'Running with code version: {sha}')
         if diff:
             log.debug(f'With uncommitted changes:\n{diff}')


### PR DESCRIPTION
This PR fixes an error that resulted from logging the git commit when not installing deepqmc from a git repository. Now it logs the deepqmc version instead. 

`>  DEBUG:deepqmc.app: Running with code version: deepqmc 1.2.0`