### PR TITLE
fix dependency bug with (test) PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     'pyyaml',
     'tqdm',
     'uncertainties',
+    'chex<1.0.0'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
When installing from test PyPI the `chex` dependency was resolved incorrectly (even when using the `--extra-index-url https://pypi.org/simple` option. In principle, restricting it to `chex<1.0.0` should not be necessary, but this PR will prevent the problem from recurring.