### PR TITLE
Fix force logging, improve observable logging

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -131,7 +131,15 @@ Furthermore, several other quantities are dumped during the training to the ``wo
     >>> with h5py.File('runs/01/training/result.h5') as f: print(f.keys(),f['local_energy'].keys())
     <KeysViewHDF5 ['local_energy']> <KeysViewHDF5 ['max', 'mean', 'min', 'samples', 'std']>
 
-Additional observables can also be computed and logged during a run by specifying the ``observable_monitors`` argument to :func:`~deepqmc.train.train`. See also the :mod:`~deepqmc.observable` submodule for more details.
+Additional observables can also be computed and logged during a run by specifying the ``observable_monitors`` argument to :func:`~deepqmc.train.train`.
+For example, to evaluate the spin of the wave function during training one can use the :class:`~deepqmc.observable.SpinMonitor` class::
+
+    from deepqmc.observable import SpinMonitor
+    observable_monitors = [SpinMonitor(period=1, save_samples=True)]
+    train(H, ansatz, kfac, sampler_factory, steps=10000, electron_batch_size=2000, seed=42, workdir='runs/02', observable_monitors=observable_monitors)
+
+Then the ``runs/02/training/result.h5`` file will contain the keys ``spin/samples``, ``spin/mean``, and ``spin/std``.
+See also the :mod:`~deepqmc.observable` submodule for more details.
 
 Evaluate the energy
 -------------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -139,6 +139,7 @@ For example, to evaluate the spin of the wave function during training one can u
     train(H, ansatz, kfac, sampler_factory, steps=10000, electron_batch_size=2000, seed=42, workdir='runs/02', observable_monitors=observable_monitors)
 
 Then the ``runs/02/training/result.h5`` file will contain the keys ``spin/samples``, ``spin/mean``, and ``spin/std``.
+Note: since logging all samples can result in very large ``result.h5`` files, it may be useful to disable saving of individual samples by setting save_samples=False if not explicitly required.
 See also the :mod:`~deepqmc.observable` submodule for more details.
 
 Evaluate the energy

--- a/src/deepqmc/conf/task/evaluate_forces.yaml
+++ b/src/deepqmc/conf/task/evaluate_forces.yaml
@@ -20,7 +20,6 @@ h5_logger:
   _partial_: true
   keys_whitelist:
     - mol_idxs
-    - local_energy
     - time
     - step
     - hf_force_bare

--- a/src/deepqmc/conf/task/evaluate_forces.yaml
+++ b/src/deepqmc/conf/task/evaluate_forces.yaml
@@ -3,24 +3,16 @@ evaluate: true
 keep_sampler_state: true
 restdir: ???
 observable_monitors:
-  - _target_: deepqmc.observable.EnergyMonitor
-    _partial_: false
-    save_samples: True
-    period: 1
   - _target_: deepqmc.observable.ACZVQForceMonitor
-    _partial_: false
     save_samples: True
     period: 1
   - _target_: deepqmc.observable.ACZVForceMonitor
-    _partial_: false
     save_samples: True
     period: 1
   - _target_: deepqmc.observable.ACZVZBQForceMonitor
-    _partial_: false
     save_samples: True
     period: 1
   - _target_: deepqmc.observable.ACZVZBForceMonitor
-    _partial_: false
     save_samples: True
     period: 1
 h5_logger:

--- a/src/deepqmc/conf/task/train.yaml
+++ b/src/deepqmc/conf/task/train.yaml
@@ -31,15 +31,6 @@ loss_function_factory:
 mols:
   _target_: deepqmc.app.read_molecules
   directory: null
-observable_monitors:
-  - _target_: deepqmc.observable.EnergyMonitor
-    _partial_: false
-    save_samples: true
-    period: 1
-  - _target_: deepqmc.observable.WaveFunctionMonitor
-    _partial_: false
-    save_samples: true
-    period: 1
 metric_logger_constructor:
   _target_: deepqmc.log.TensorboardMetricLogger
   _partial_: true

--- a/src/deepqmc/conf/task/train.yaml
+++ b/src/deepqmc/conf/task/train.yaml
@@ -41,5 +41,3 @@ chkpt_constructor:
 h5_logger_constructor:
   _target_: deepqmc.log.H5Logger
   _partial_: true
-  keys_whitelist:
-    - local_energy

--- a/src/deepqmc/conf/task/train_excited_psiformer.yaml
+++ b/src/deepqmc/conf/task/train_excited_psiformer.yaml
@@ -67,16 +67,7 @@ h5_logger_constructor:
     - 'overlap/pairwise'
     - 'time'
 observable_monitors:
-  - _target_: deepqmc.observable.EnergyMonitor
-    _partial_: false
-    save_samples: True
-    period: 1
-  - _target_: deepqmc.observable.WaveFunctionMonitor
-    _partial_: false
-    save_samples: True
-    period: 1
   - _target_: deepqmc.observable.SpinMonitor
-    _partial_: false
     save_samples: False
     period: 1
 mols:

--- a/src/deepqmc/conf/task/train_excited_psiformer.yaml
+++ b/src/deepqmc/conf/task/train_excited_psiformer.yaml
@@ -61,8 +61,6 @@ h5_logger_constructor:
   _target_: deepqmc.log.H5Logger
   _partial_: true
   keys_whitelist:
-    - 'local_energy'
-    - 'energy'
     - 'spin'
     - 'overlap/pairwise'
     - 'time'

--- a/src/deepqmc/conf/task/train_ferminet.yaml
+++ b/src/deepqmc/conf/task/train_ferminet.yaml
@@ -36,8 +36,6 @@ chkpt_constructor:
 h5_logger_constructor:
   _target_: deepqmc.log.H5Logger
   _partial_: true
-  keys_whitelist:
-    - local_energy
 mols:
   _target_: deepqmc.app.read_molecules
   directory: null

--- a/src/deepqmc/conf/task/train_psiformer.yaml
+++ b/src/deepqmc/conf/task/train_psiformer.yaml
@@ -36,8 +36,6 @@ chkpt_constructor:
 h5_logger_constructor:
   _target_: deepqmc.log.H5Logger
   _partial_: true
-  keys_whitelist:
-    - local_energy
 mols:
   _target_: deepqmc.app.read_molecules
   directory: null

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -202,7 +202,7 @@ class H5Logger:
     def __init__(
         self,
         workdir: str,
-        observable_names: Optional[list[str]] = None,
+        additional_keys_to_whitelist: Optional[list[str]] = None,
         *,
         keys_whitelist: Optional[list[str]] = None,
         init_step: int = 0,
@@ -210,7 +210,7 @@ class H5Logger:
     ):
         self.keys_whitelist = (
             keys_whitelist if keys_whitelist is not None else ['local_energy']
-        ) + (observable_names or [])
+        ) + (additional_keys_to_whitelist or [])
         self.h5file = h5py.File(os.path.join(workdir, 'result.h5'), 'a', libver='v110')
         self.h5file.swmr_mode = True
         for k, v in (aux_data or {}).items():

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 import re
@@ -26,6 +27,7 @@ from .types import Stats, TrainState
 from .utils import flatten_dict, tree_any
 
 __all__ = ['CheckpointStore', 'H5LogTable', 'TensorboardMetricLogger']
+log = logging.getLogger(__name__)
 
 
 class Checkpoint(NamedTuple):
@@ -344,9 +346,11 @@ class TensorboardMetricLogger:
                     )
                 ]
             else:
-                raise ValueError(
-                    f'Invalid dimension ({v.ndim}) for {k} (shape: {v.shape}).'
+                log.warning(
+                    f'Invalid dimension ({v.ndim}) for {k} (shape: {v.shape}), '
+                    'excluding it from Tensorboard log.'
                 )
+                continue
             group = k.split('/')[0]
             self.layout[f'{prefix}{group}'] = {
                 k: ['Multiline', keys],
@@ -406,9 +410,11 @@ class TensorboardMetricLogger:
                     for j, l in product(range(v.shape[1]), range(v.shape[2]))
                 ]
             else:
-                raise ValueError(
-                    f'Invalid dimension ({v.ndim}) for {k} (shape: {v.shape}).'
+                log.warning(
+                    f'Invalid dimension ({v.ndim}) for {k} (shape: {v.shape}), '
+                    'excluding it from Tensorboard log.'
                 )
+                continue
             group = k.split('/')[0]
             self.layout[f'{prefix}{group}'] = {
                 k: ['Multiline', keys],

--- a/src/deepqmc/log.py
+++ b/src/deepqmc/log.py
@@ -202,6 +202,7 @@ class H5Logger:
     def __init__(
         self,
         workdir: str,
+        observable_names: Optional[list[str]] = None,
         *,
         keys_whitelist: Optional[list[str]] = None,
         init_step: int = 0,
@@ -209,7 +210,7 @@ class H5Logger:
     ):
         self.keys_whitelist = (
             keys_whitelist if keys_whitelist is not None else ['local_energy']
-        )
+        ) + (observable_names or [])
         self.h5file = h5py.File(os.path.join(workdir, 'result.h5'), 'a', libver='v110')
         self.h5file.swmr_mode = True
         for k, v in (aux_data or {}).items():

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -161,6 +161,7 @@ def train(  # noqa: C901
         log.debug('Setting up h5_logger...')
         h5_logger = (h5_logger_constructor or H5Logger)(
             workdir,
+            [observable.name for observable in observable_monitors or []],
             init_step=init_step,
             aux_data={f'mol-{i}': m.coords for i, m in enumerate(mols)},
         )

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -148,6 +148,7 @@ def train(  # noqa: C901
         molecule_batch_size,
     )
     opt = opt or NoOptimizer
+    observable_monitors = default_observable_monitors() + (observable_monitors or [])
     chkpts = None
     if workdir:
         workdir = os.path.join(workdir, mode + process_idx_suffix())
@@ -278,7 +279,6 @@ def train(  # noqa: C901
                 assert chkpts
                 chkpts.update(init_step, train_state)
             log.info(f'Start {mode}')
-        observable_monitors = observable_monitors or default_observable_monitors()
         loss_function_factory = loss_function_factory or partial(
             create_loss_fn, clip_mask_fn=median_log_squeeze_and_mask
         )

--- a/src/deepqmc/train.py
+++ b/src/deepqmc/train.py
@@ -161,7 +161,7 @@ def train(  # noqa: C901
         log.debug('Setting up h5_logger...')
         h5_logger = (h5_logger_constructor or H5Logger)(
             workdir,
-            [observable.name for observable in observable_monitors or []],
+            [observable.name for observable in observable_monitors],
             init_step=init_step,
             aux_data={f'mol-{i}': m.coords for i, m in enumerate(mols)},
         )


### PR DESCRIPTION
This PR does four things:

1. It fixes #215 , by turning the error thrown by `TensorboardLogger` to a warning.
2. It makes sure that the energy, and wave function observable monitors are always used, as these are currently necessary for the functioning of the training loop.
3. It automatically whitelists all quantities produced by the observable monitors in `H5Logger`, which is the most likely intention when one specifies observable monitors. This avoids the need to manually specify a whitelist entry for all observable monitors.
4. It adds an example on the usage of observable monitors to `tutorial.rst`.