### PR TITLE
simplify ECP data loading

### DIFF
--- a/src/deepqmc/ecp/gaussian_type_ecp.py
+++ b/src/deepqmc/ecp/gaussian_type_ecp.py
@@ -41,7 +41,7 @@ def parse_gaussian_type_ecp_params(charges, ecp_type, ecp_mask):
             data = load_ecp(ecp_type, [ELEMENTS[int(atomic_number)]])
             assert data, (
                 f'Effective core potential of type {ecp_type} not found for'
-                f' {ELEMENTS[atomic_number]} atom.'
+                f' {ELEMENTS[int(atomic_number)]} atom.'
             )
             ecp_loc_param = data[1][0][1][1:4]
             if len(data[1]) > 1:


### PR DESCRIPTION
This PR addresses issue #225 by removing the unnecessary pyscf molecule construction and instead loading the ECP parameters directly from pyscf using `load_ecp` function.