### PR TITLE
update jax install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The above installation will result in the CPU version of JAX. However, running D
 
 ```
 # CUDA 12 installation
-pip install --upgrade "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 For further help setting up JAX, visit the [JAX Install Guide](https://github.com/google/jax#installation).

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -81,9 +81,10 @@ If `Pip <https://pip.pypa.io/en/stable/quickstart/>`_ complains about ``setup.py
 The above installation will result in the CPU version of JAX. However, running DeepQMC on the GPU is highly recommended. To enable GPU support make sure to upgrade JAX to match the CUDA and cuDNN versions of your system. For most users this can be achieved with::
 
     $ # CUDA 12 installation
-    $ pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+    $ pip install "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-If issues arise during the installation of JAX, or if errors related to CUDA or cuDNN occur at runtime, please visit the `JAX Install Guide <https://github.com/google/jax#installation>`_.
+If issues arise during the installation of JAX, or if errors related to CUDA or cuDNN occur at runtime, please visit the `JAX Install Guide <https://github.com/google/jax#installation>`_. Note that the latest JAX version may not be compatible with DeepQMC, see dependencies in `pyproject.toml
+<https://github.com/deepqmc/deepqmc/blob/master/pyproject.toml>`_.
 
 To validate your installation run::
 

--- a/src/deepqmc/wf/cusp.py
+++ b/src/deepqmc/wf/cusp.py
@@ -39,7 +39,7 @@ class CuspAsymptotic(hk.Module):
             hk.get_parameter(
                 f'{name}_alpha',
                 (),
-                init=lambda s, d: jnp.array(value, dtype=d).reshape(s),
+                init=lambda s, d: jnp.array(value).reshape(s),
             )
             if self.trainable_alpha
             else jnp.array(value, dtype=float)

--- a/src/deepqmc/wf/omni.py
+++ b/src/deepqmc/wf/omni.py
@@ -188,7 +188,7 @@ class NuclearGNNHead(hk.Module):
             return glu_out + hk.get_parameter(
                 f'{key}_bias_{spin}',
                 glu_out.shape,
-                init=lambda s, d: 2 * jnp.ones(s, d),
+                init=lambda s, d: 2 * jnp.ones(s),
             )
 
         return readout


### PR DESCRIPTION
`--upgrade` would override the version cap from pyproject. Newer jax versions don't have cuda12_pip option, just cuda12