### PR TITLE
Stop gradient of the exp-normalize shift in NeuralNetworkWaveFunction

### DIFF
--- a/src/deepqmc/wf/nn_wave_function.py
+++ b/src/deepqmc/wf/nn_wave_function.py
@@ -153,6 +153,7 @@ class NeuralNetworkWaveFunction(hk.Module):
         # the exp-normalize trick, to avoid over/underflow of the exponential
         xs_shift = jnp.where(~jnp.isinf(xs_shift), xs_shift, jnp.zeros_like(xs_shift))
         # replace -inf shifts, to avoid running into nans (see sloglindet)
+        xs_shift = jax.lax.stop_gradient(xs_shift)
         xs = sign * jnp.exp(xs - xs_shift)
         psi = self.conf_coeff(xs).squeeze()
         log_psi = jnp.log(jnp.abs(psi)) + xs_shift


### PR DESCRIPTION
## TL;DR

A single line is added to stop the gradient of the exp-normalize shift `xs_shift` in
`NeuralNetworkWaveFunction.__call__`.  The gradient is not needed while also being the source of a latent `NaN`.

## Why stop the gradient
The exp-normalize trick is used to sum up the different determinants in `NeuralNetworkWaveFunction`. The maximum exponent (`xs_shift`) is subtracted from all exponents before summing, and added back afterwards for numerical stability. Mathematically, `log_psi` is independent of `xs_shift` and the gradient of `xs_shift` is not needed for correctness. Not computing it saves unnecessary computation. `jax.nn.logsumexp` also stops the gradient of its max.

Apart from unnecessary compute, taking the gradient of `jnp.max` (i.e. `xs_shift` here) sometimes causes a `NaN`:

`jnp.max(xs)` is differentiated as

`sum(mask * tangent) / sum(mask)` with `mask = (xs == xs.max())`

and when XLA recomputes `xs` in a different fusion than `xs.max()`, then ` xs == xs.max()` is all `False` because they don't agree bit for bit, resulting in 0/0. (Claude did heavy lifting to find this out.)

### Possibly similar problem in additive backflow
This bug could in theory also arise in the additive backflow in [nn_wave_function.py:29](https://github.com/deepqmc/deepqmc/blob/a81da0e92eef415aca91b788b6bc906664abea55/src/deepqmc/wf/nn_wave_function.py#L29) where `jnp.min` is differentiated. Here, the gradient can not just be stopped, so another fix would be necessary.

